### PR TITLE
Remove note about intremap=nosid parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,6 @@ is appreciated.
 | [Wi-Fi](#wi-fi) | :heavy_check_mark: working for MacBookPro13,1<br />:x: not working for MacBookPro13,2 & MacBookPro13,3 |
 
 
-## Booting
-
-To boot Linux properly, it's necessary to set `intremap=nosid` as kernel boot
-parameter.
-
-
 ## Audio input & output
 
 Not working, neither the internal speakers/microphone nor the headphone jack.


### PR DESCRIPTION
@bubuntux noted in #21, that everything works fine for him, without specifying `intremap=nosid` as kernel boot parameter. I tried that out as well and indeed, so far everything is working as expected.

Can somebody else confirm that as well?

I was also looking into where that information came from and one source is the applespi driver, whose README states:
> To get this driver to work on a 2016 12" MacBook, you'll need to boot the kernel with `intremap=nosid`.

Either that's not the case for the MacBookPro13,x or it's not the case anymore at all.