### PR TITLE
Add palm rejection support for touchpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ follow the instructions for the [Touch Bar](#touch-bar) to get it working.
 Beside the actual keyboard the power button and the lid close event work out of
 the box.
 
+Palm rejection based on touch-sizes and disable-touchpad-while-typing are working 
+with [this patch](https://gist.github.com/peterychuang/5cf9bf527bc26adef47d714c758a5509)
+to [libinput](https://cgit.freedesktop.org/wayland/libinput) (master branch).
+
 See also:
 * https://bugzilla.kernel.org/show_bug.cgi?id=99891
 * https://bugzilla.kernel.org/show_bug.cgi?id=108331


### PR DESCRIPTION
Add the libinput patch that enables touch-size based palm rejection and disable-while-typing for the touchpad.

See [this thread](https://github.com/Dunedan/mbp-2016-linux/issues/20) for the relevant discussion.