### PR TITLE
Dump all ACPI tables instead of just the DSDT.

### DIFF
--- a/get-info.sh
+++ b/get-info.sh
@@ -29,7 +29,7 @@ else
     cp $global_log "$dir"/Xorg.0.log
 fi
 
-echo "getting DSDT"
-sudo cat /sys/firmware/acpi/tables/DSDT > "$dir"/dsdt.dat
+echo "getting ACPI tables"
+sudo acpidump > "$dir"/acpidump
 
 echo "done!"


### PR DESCRIPTION
In particular, the iBridge's entry is found in the supplementary tables
(SSDT's) instead of the DSDT, so it's important to have everything.

This does require that the acpica-tools (or equivalent) package is
installed.