### PR TITLE
Add information about non-tMBP Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ https://support.apple.com/en-us/HT201300, or use the [EveryMac serial number loo
 ## Contribution
 
 If you want to contribute to get Linux running smoothly on these devices, please report any findings on how to get devices working as pull requests! All help
-is appreciated.
+is appreciated. Feel free to check below for badges with the "unknown" status.
 
 There is also a chat available via gitter for discussions:
 [![Gitter chat](https://badges.gitter.im/Dunedan/mbp-2016-linux.png)](https://gitter.im/mbp-2016-linux/Lobby)
 
 ## Current status
 
-If a section applies only to a certain subset of models, "all models" refers to that subset.
+If a section applies only to a certain subset of models, "all models" refers to that subset. If a device's status is unknown, it is not listed.
 
 | Device  | Status |
 | ------- | ------ |
@@ -52,8 +52,7 @@ If a section applies only to a certain subset of models, "all models" refers to 
 
 ## Audio input & output
 
-![MacBookPro13,1 not working](https://img.shields.io/badge/MacBookPro13%2C1-not_working-red.svg) ![MacBookPro13,2 not working](https://img.shields.io/badge/MacBookPro13%2C2-not_working-red.svg) ![MacBookPro13,3 not working](https://img.shields.io/badge/MacBookPro13%2C3-not_working-red.svg) ![MacBookPro14,1 not working](https://img.shields.io/badge/MacBookPro14%2C1-not_working-red.svg) ![MacBookPro14,2 not working](https://img.shields.io/badge/MacBookPro14%2C2-not_working-red.svg) ![MacBookPro14,3 not working](https://img.shields.io/badge/MacBookPro14%2C3-not_working-red.svg)
-![iMacPro1,1 not working](https://img.shields.io/badge/iMacPro1%2C1-not_working-red.svg) ![Macmini8,1 not working](https://img.shields.io/badge/Macmini8%2C1-not_working-red.svg) ![MacBookAir8,1 not working](https://img.shields.io/badge/MacBookAir8%2C1-not_working-red.svg) ![MacBookAir8,2 not working](https://img.shields.io/badge/MacBookAir8%2C2-not_working-red.svg)
+![MacBookPro13,1 not working](https://img.shields.io/badge/MacBookPro13%2C1-not_working-red.svg) ![MacBookPro13,2 not working](https://img.shields.io/badge/MacBookPro13%2C2-not_working-red.svg) ![MacBookPro13,3 not working](https://img.shields.io/badge/MacBookPro13%2C3-not_working-red.svg) ![MacBookPro14,1 not working](https://img.shields.io/badge/MacBookPro14%2C1-not_working-red.svg) ![MacBookPro14,2 not working](https://img.shields.io/badge/MacBookPro14%2C2-not_working-red.svg) ![MacBookPro14,3 not working](https://img.shields.io/badge/MacBookPro14%2C3-not_working-red.svg) ![MacBookAir8,1 not working](https://img.shields.io/badge/MacBookAir8%2C1-not_working-red.svg) ![MacBookAir8,2 not working](https://img.shields.io/badge/MacBookAir8%2C2-not_working-red.svg) ![MacBook8,1 unknown](https://img.shields.io/badge/MacBook8%2C1-unknown-blue.svg) ![MacBook9,1 unknown](https://img.shields.io/badge/MacBook9%2C1-unknown-blue.svg) ![MacBook10,1 unknown](https://img.shields.io/badge/MacBook10%2C1-unknown-blue.svg) ![iMacPro1,1 not working](https://img.shields.io/badge/iMacPro1%2C1-not_working-red.svg) ![Macmini8,1 not working](https://img.shields.io/badge/Macmini8%2C1-not_working-red.svg)
 
 Not working, neither the internal speakers/microphone nor the headphone jack.
 
@@ -68,7 +67,7 @@ See also:
 
 ## Battery
 
-![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg)
+![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg) ![MacBookAir8,1 unknown](https://img.shields.io/badge/MacBookAir8%2C1-unknown-blue.svg) ![MacBookAir8,2 unknown](https://img.shields.io/badge/MacBookAir8%2C2-unknown-blue.svg) ![MacBook8,1 unknown](https://img.shields.io/badge/MacBook8%2C1-unknown-blue.svg) ![MacBook9,1 unknown](https://img.shields.io/badge/MacBook9%2C1-unknown-blue.svg) ![MacBook10,1 unknown](https://img.shields.io/badge/MacBook10%2C1-unknown-blue.svg)
 
 Working fine, including the interface to get current capacity, temperature,
 etc.
@@ -80,7 +79,7 @@ than 4 hours.
 
 ## Bluetooth
 
-![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg)
+![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg) !![MacBookAir8,1 unknown](https://img.shields.io/badge/MacBookAir8%2C1-unknown-blue.svg) ![MacBookAir8,2 unknown](https://img.shields.io/badge/MacBookAir8%2C2-unknown-blue.svg) ![MacBook8,1 unknown](https://img.shields.io/badge/MacBook8%2C1-unknown-blue.svg) ![MacBook9,1 unknown](https://img.shields.io/badge/MacBook9%2C1-unknown-blue.svg) ![MacBook10,1 unknown](https://img.shields.io/badge/MacBook10%2C1-unknown-blue.svg) ![iMacPro1,1 unknown](https://img.shields.io/badge/iMacPro1%2C1-unknown-blue.svg) ![Macmini8,1 unknown](https://img.shields.io/badge/Macmini8%2C1-unknown-blue.svg)
 
 Works out of the box with Linux 4.16 and above, except for the models without
 Touch Bar, which still suffers from a bug and needs an additional patch as noted
@@ -99,7 +98,7 @@ See also:
 
 ## FaceTime HD camera
 
-![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg)
+![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg) ![MacBookAir8,1 unknown](https://img.shields.io/badge/MacBookAir8%2C1-unknown-blue.svg) ![MacBookAir8,2 unknown](https://img.shields.io/badge/MacBookAir8%2C2-unknown-blue.svg) ![MacBook8,1 unknown](https://img.shields.io/badge/MacBook8%2C1-unknown-blue.svg) ![MacBook9,1 unknown](https://img.shields.io/badge/MacBook9%2C1-unknown-blue.svg) ![MacBook10,1 unknown](https://img.shields.io/badge/MacBook10%2C1-unknown-blue.svg) ![iMacPro1,1 unknown](https://img.shields.io/badge/iMacPro1%2C1-unknown-blue.svg) ![Macmini8,1 unknown](https://img.shields.io/badge/Macmini8%2C1-unknown-blue.svg)
 
 In the MacBookPro13,1 (without Touch Bar) the FaceTime HD camera is connected
 via PCIe, like in previous MacBook Pro's. It's working with the
@@ -114,7 +113,7 @@ supported by the `uvcvideo` driver out of the box.
 
 ### Intel
 
-![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg)
+![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg) ![MacBookAir8,1 unknown](https://img.shields.io/badge/MacBookAir8%2C1-unknown-blue.svg) ![MacBookAir8,2 unknown](https://img.shields.io/badge/MacBookAir8%2C2-unknown-blue.svg) ![MacBook8,1 unknown](https://img.shields.io/badge/MacBook8%2C1-unknown-blue.svg) ![MacBook9,1 unknown](https://img.shields.io/badge/MacBook9%2C1-unknown-blue.svg) ![MacBook10,1 unknown](https://img.shields.io/badge/MacBook10%2C1-unknown-blue.svg) ![iMacPro1,1 unknown](https://img.shields.io/badge/iMacPro1%2C1-unknown-blue.svg) ![Macmini8,1 unknown](https://img.shields.io/badge/Macmini8%2C1-unknown-blue.svg)
 
 Graphical output using the Intel GPU is working out of the box on the
 MacBookPro 13,1 and 13,2, without dedicated AMD GPU. For the MacBookPro 13,3
@@ -130,13 +129,13 @@ displays daisy-chained together with Full HD each.
 
 ### AMD
 
-![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg)
+![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg) ![iMacPro1,1 unknown](https://img.shields.io/badge/iMacPro1%2C1-unknown-blue.svg) ![Macmini8,1 unknown](https://img.shields.io/badge/Macmini8%2C1-unknown-blue.svg)
 
 Works out of the box.
 
 ## Keyboard & Touchpad
 
-![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg)
+![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg) ![MacBookAir8,1 unknown](https://img.shields.io/badge/MacBookAir8%2C1-unknown-blue.svg) ![MacBookAir8,2 unknown](https://img.shields.io/badge/MacBookAir8%2C2-unknown-blue.svg) ![MacBook8,1 unknown](https://img.shields.io/badge/MacBook8%2C1-unknown-blue.svg) ![MacBook9,1 unknown](https://img.shields.io/badge/MacBook9%2C1-unknown-blue.svg) ![MacBook10,1 unknown](https://img.shields.io/badge/MacBook10%2C1-unknown-blue.svg) ![iMacPro1,1 unknown](https://img.shields.io/badge/iMacPro1%2C1-unknown-blue.svg) ![Macmini8,1 unknown](https://img.shields.io/badge/Macmini8%2C1-unknown-blue.svg)
 
 Works out of the box with Linux 5.3 and above.
 
@@ -160,7 +159,7 @@ See also:
 
 ## NVMe
 
-![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg)
+![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg) ![MacBookAir8,1 unknown](https://img.shields.io/badge/MacBookAir8%2C1-unknown-blue.svg) ![MacBookAir8,2 unknown](https://img.shields.io/badge/MacBookAir8%2C2-unknown-blue.svg) ![MacBook8,1 unknown](https://img.shields.io/badge/MacBook8%2C1-unknown-blue.svg) ![MacBook9,1 unknown](https://img.shields.io/badge/MacBook9%2C1-unknown-blue.svg) ![MacBook10,1 unknown](https://img.shields.io/badge/MacBook10%2C1-unknown-blue.svg) ![iMacPro1,1 unknown](https://img.shields.io/badge/iMacPro1%2C1-unknown-blue.svg) ![Macmini8,1 unknown](https://img.shields.io/badge/Macmini8%2C1-unknown-blue.svg)
 
 Works out of the box.
 
@@ -170,7 +169,7 @@ power than they need to, therefore reducing the battery life.
 
 ## Screen
 
-![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg)
+![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg) ![MacBookAir8,1 unknown](https://img.shields.io/badge/MacBookAir8%2C1-unknown-blue.svg) ![MacBookAir8,2 unknown](https://img.shields.io/badge/MacBookAir8%2C2-unknown-blue.svg) ![MacBook8,1 unknown](https://img.shields.io/badge/MacBook8%2C1-unknown-blue.svg) ![MacBook9,1 unknown](https://img.shields.io/badge/MacBook9%2C1-unknown-blue.svg) ![MacBook10,1 unknown](https://img.shields.io/badge/MacBook10%2C1-unknown-blue.svg) ![iMacPro1,1 unknown](https://img.shields.io/badge/iMacPro1%2C1-unknown-blue.svg) ![Macmini8,1 unknown](https://img.shields.io/badge/Macmini8%2C1-unknown-blue.svg)
 
 Works out of the box.
 
@@ -185,7 +184,7 @@ doesn't matter, as Xorg probes and sets the correct resolution of `2560x1600`.
 
 ## Suspend & Hibernation
 
-![MacBookPro13,1 not working](https://img.shields.io/badge/MacBookPro13%2C1-not_working-red.svg) ![MacBookPro13,2 not working](https://img.shields.io/badge/MacBookPro13%2C2-not_working-red.svg) ![MacBookPro13,3 not working](https://img.shields.io/badge/MacBookPro13%2C3-not_working-red.svg) ![MacBookPro14,1 not working](https://img.shields.io/badge/MacBookPro14%2C1-not_working-red.svg) ![MacBookPro14,2 not working](https://img.shields.io/badge/MacBookPro14%2C2-not_working-red.svg) ![MacBookPro14,3 not working](https://img.shields.io/badge/MacBookPro14%2C3-not_working-red.svg)
+![MacBookPro13,1 not working](https://img.shields.io/badge/MacBookPro13%2C1-not_working-red.svg) ![MacBookPro13,2 not working](https://img.shields.io/badge/MacBookPro13%2C2-not_working-red.svg) ![MacBookPro13,3 not working](https://img.shields.io/badge/MacBookPro13%2C3-not_working-red.svg) ![MacBookPro14,1 not working](https://img.shields.io/badge/MacBookPro14%2C1-not_working-red.svg) ![MacBookPro14,2 not working](https://img.shields.io/badge/MacBookPro14%2C2-not_working-red.svg) ![MacBookPro14,3 not working](https://img.shields.io/badge/MacBookPro14%2C3-not_working-red.svg) ![MacBookAir8,1 unknown](https://img.shields.io/badge/MacBookAir8%2C1-unknown-blue.svg) ![MacBookAir8,2 unknown](https://img.shields.io/badge/MacBookAir8%2C2-unknown-blue.svg) ![MacBook8,1 unknown](https://img.shields.io/badge/MacBook8%2C1-unknown-blue.svg) ![MacBook9,1 unknown](https://img.shields.io/badge/MacBook9%2C1-unknown-blue.svg) ![MacBook10,1 unknown](https://img.shields.io/badge/MacBook10%2C1-unknown-blue.svg) ![iMacPro1,1 unknown](https://img.shields.io/badge/iMacPro1%2C1-unknown-blue.svg) ![Macmini8,1 unknown](https://img.shields.io/badge/Macmini8%2C1-unknown-blue.svg)
 
 Putting the MacBook Pro into suspend mode works, but it doesn't wake up again.
 @roadrunner2 did some work in this area. You'll find some details about it in
@@ -194,7 +193,7 @@ https://github.com/cb22/macbook12-spi-driver/pull/30#issuecomment-306316034
 
 ## System Management Controller
 
-![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg)
+![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg) ![MacBookAir8,1 unknown](https://img.shields.io/badge/MacBookAir8%2C1-unknown-blue.svg) ![MacBookAir8,2 unknown](https://img.shields.io/badge/MacBookAir8%2C2-unknown-blue.svg) ![MacBook8,1 unknown](https://img.shields.io/badge/MacBook8%2C1-unknown-blue.svg) ![MacBook9,1 unknown](https://img.shields.io/badge/MacBook9%2C1-unknown-blue.svg) ![MacBook10,1 unknown](https://img.shields.io/badge/MacBook10%2C1-unknown-blue.svg) ![iMacPro1,1 unknown](https://img.shields.io/badge/iMacPro1%2C1-unknown-blue.svg) ![Macmini8,1 unknown](https://img.shields.io/badge/Macmini8%2C1-unknown-blue.svg)
 
 The System Management Controller (SMC) is responsible for interactions with
 sensors and fans.
@@ -219,7 +218,7 @@ An accelerometer isn't available at all.
 
 ## Thunderbolt
 
-![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg)
+![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg) ![MacBookAir8,1 unknown](https://img.shields.io/badge/MacBookAir8%2C1-unknown-blue.svg) ![MacBookAir8,2 unknown](https://img.shields.io/badge/MacBookAir8%2C2-unknown-blue.svg) ![iMacPro1,1 unknown](https://img.shields.io/badge/iMacPro1%2C1-unknown-blue.svg) ![Macmini8,1 unknown](https://img.shields.io/badge/Macmini8%2C1-unknown-blue.svg)
 
 Works out of the box.
 
@@ -249,7 +248,7 @@ Not working.
 
 ## USB
 
-![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg)
+![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 working](https://img.shields.io/badge/MacBookPro13%2C2-working-green.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 working](https://img.shields.io/badge/MacBookPro14%2C2-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg) ![MacBookAir8,1 unknown](https://img.shields.io/badge/MacBookAir8%2C1-unknown-blue.svg) ![MacBookAir8,2 unknown](https://img.shields.io/badge/MacBookAir8%2C2-unknown-blue.svg) ![MacBook8,1 unknown](https://img.shields.io/badge/MacBook8%2C1-unknown-blue.svg) ![MacBook9,1 unknown](https://img.shields.io/badge/MacBook9%2C1-unknown-blue.svg) ![MacBook10,1 unknown](https://img.shields.io/badge/MacBook10%2C1-unknown-blue.svg) ![iMacPro1,1 unknown](https://img.shields.io/badge/iMacPro1%2C1-unknown-blue.svg) ![Macmini8,1 unknown](https://img.shields.io/badge/Macmini8%2C1-unknown-blue.svg)
 
 Works out of the box.
 
@@ -258,7 +257,7 @@ Works out of the box.
 
 ![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 not working](https://img.shields.io/badge/MacBookPro13%2C2-not_working-red.svg) ![MacBookPro13,3 not working](https://img.shields.io/badge/MacBookPro13%2C3-not_working-red.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 not working](https://img.shields.io/badge/MacBookPro14%2C2-not_working-red.svg) ![MacBookPro14,3 not working](https://img.shields.io/badge/MacBookPro14%2C3-not_working-red.svg)
 ![MacBookAir8,1 not working](https://img.shields.io/badge/MacBookAir8%2C1-not_working-red.svg)
-![MacBookAir8,2 not working](https://img.shields.io/badge/MacBookAir8%2C2-not_working-red.svg)
+![MacBookAir8,2 not working](https://img.shields.io/badge/MacBookAir8%2C2-not_working-red.svg) ![iMacPro1,1 unknown](https://img.shields.io/badge/iMacPro1%2C1-unknown-blue.svg) ![Macmini8,1 unknown](https://img.shields.io/badge/Macmini8%2C1-unknown-blue.svg)
 
 The MacBook Pro models without Touch Bar come with a `Broadcom Limited BCM4350
 802.11ac Wireless Network Adapter` which works fine out of the box using the
@@ -275,8 +274,6 @@ According to Broadcom releasing a fixed firmware would require verification to
 ensure that it complies with regulatory limits, which is very unlikely to
 happen as it wouldn't provide enough return on investment for them (see
 https://bugzilla.kernel.org/show_bug.cgi?id=193121 for details).
-
-Re
 
 ## Misc
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ There is also a chat available via gitter for discussions:
 ## Audio input & output
 
 ![MacBookPro13,1 not working](https://img.shields.io/badge/MacBookPro13%2C1-not_working-red.svg) ![MacBookPro13,2 not working](https://img.shields.io/badge/MacBookPro13%2C2-not_working-red.svg) ![MacBookPro13,3 not working](https://img.shields.io/badge/MacBookPro13%2C3-not_working-red.svg) ![MacBookPro14,1 not working](https://img.shields.io/badge/MacBookPro14%2C1-not_working-red.svg) ![MacBookPro14,2 not working](https://img.shields.io/badge/MacBookPro14%2C2-not_working-red.svg) ![MacBookPro14,3 not working](https://img.shields.io/badge/MacBookPro14%2C3-not_working-red.svg)
+![iMacPro1,1 not working](https://img.shields.io/badge/iMacPro1%2C1-not_working-red.svg) ![Macmini8,1 not working](https://img.shields.io/badge/Macmini8%2C1-not_working-red.svg) ![MacBookAir8,1 not working](https://img.shields.io/badge/MacBookAir8%2C1-not_working-red.svg) ![MacBookAir8,2 not working](https://img.shields.io/badge/MacBookAir8%2C2-not_working-red.svg)
 
 Not working, neither the internal speakers/microphone nor the headphone jack.
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,27 @@
-# State of Linux on the MacBook Pro 2016 & 2017
+# State of Linux on Post-2015 Macs
 
-The following document provides an overview about Linux support for Apple's
-MacBook Pro 2016 and MacBook Pro 2017 models.
+The following document provides an overview about Linux support for Apple's newer Mac devices. This includes:
 
-The MacBook Pro 2016 shares surprisingly many components with the Retina
-MacBook (e.g. keyboard and touchpad controller, Wi-Fi and bluetooth chipsets,
-...), so figuring out how things work on one device should benefit both device
-families.
+- **2016 "Thunderbolt" MacBook Pro** (MacBookPro13,1 and up)
+- 2015 "Retina" MacBook Pro (MacBook8,1 - MacBook10,1)
+- 2018 "Retina" MacBook Air (MacBookAir8,1 and up)
+- 2017 iMac Pro (iMacPro1,1)
+- 2018 Mac mini (Macmini8,1)
 
-The Apple MacBook Pro 2017 models are nearly identical to their 2016
-counterparts, except for the use of newer Intels Kaby Lake processors instead
-of Intel Skylake processors, faster memory and updated AMD Radeon GPUs in the
-15-inch models.
+Many of these devices share a number of components; in particular, the keyboard and touchpad controller, Wi-Fi and Bluetooth chipsets, and T2 security chip.
 
-The checks if hardware works below were done with multiple Linux distributions.
-To state the obvious: The newer the kernel the better. The information below
+The following hardware checks were done with multiple Linux distributions. To state the obvious: The newer the kernel the better. The information below
 assumes that you run Linux 4.13 or newer. If in doubt which kernel to use, the
 latest significant improvements are part of Linux 4.16.
 
-If you don't know what the model identifier for your MacBook Pro is (as that
+If you don't know what the model identifier for your Mac is (as that
 identifier is used on several occasions below), check
-https://support.apple.com/en-us/HT201300
+https://support.apple.com/en-us/HT201300, or use the [EveryMac serial number lookup](https://everymac.com/ultimate-mac-lookup/).
 
 
 ## Contribution
 
-If you want to contribute to get Linux running smoothly on the MacBook Pro
-2016, report all findings on how to get devices working as pull requests! All help
+If you want to contribute to get Linux running smoothly on these devices, please report any findings on how to get devices working as pull requests! All help
 is appreciated.
 
 There is also a chat available via gitter for discussions:

--- a/README.md
+++ b/README.md
@@ -256,8 +256,7 @@ Works out of the box.
 ## Wi-Fi
 
 ![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 not working](https://img.shields.io/badge/MacBookPro13%2C2-not_working-red.svg) ![MacBookPro13,3 not working](https://img.shields.io/badge/MacBookPro13%2C3-not_working-red.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 not working](https://img.shields.io/badge/MacBookPro14%2C2-not_working-red.svg) ![MacBookPro14,3 not working](https://img.shields.io/badge/MacBookPro14%2C3-not_working-red.svg)
-![MacBookAir8,1 not working](https://img.shields.io/badge/MacBookAir8%2C1-not_working-red.svg)
-![MacBookAir8,2 not working](https://img.shields.io/badge/MacBookAir8%2C2-not_working-red.svg) ![iMacPro1,1 unknown](https://img.shields.io/badge/iMacPro1%2C1-unknown-blue.svg) ![Macmini8,1 unknown](https://img.shields.io/badge/Macmini8%2C1-unknown-blue.svg)
+![MacBookAir8,1 not working](https://img.shields.io/badge/MacBookAir8%2C1-not_working-red.svg) ![MacBookAir8,2 not working](https://img.shields.io/badge/MacBookAir8%2C2-not_working-red.svg) ![MacBook8,1 unknown](https://img.shields.io/badge/MacBook8%2C1-unknown-blue.svg) ![MacBook9,1 unknown](https://img.shields.io/badge/MacBook9%2C1-unknown-blue.svg) ![MacBook10,1 unknown](https://img.shields.io/badge/MacBook10%2C1-unknown-blue.svg) ![iMacPro1,1 unknown](https://img.shields.io/badge/iMacPro1%2C1-unknown-blue.svg) ![Macmini8,1 unknown](https://img.shields.io/badge/Macmini8%2C1-unknown-blue.svg)
 
 The MacBook Pro models without Touch Bar come with a `Broadcom Limited BCM4350
 802.11ac Wireless Network Adapter` which works fine out of the box using the

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ displays daisy-chained together with Full HD each.
 
 ### AMD
 
-![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg) ![iMacPro1,1 unknown](https://img.shields.io/badge/iMacPro1%2C1-unknown-blue.svg) ![Macmini8,1 unknown](https://img.shields.io/badge/Macmini8%2C1-unknown-blue.svg)
+![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg) ![iMacPro1,1 unknown](https://img.shields.io/badge/iMacPro1%2C1-unknown-blue.svg)
 
 Works out of the box.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ There is also a chat available via gitter for discussions:
 | [Touch Bar](#touch-bar) | ![MacBookPro13,2 partially working](https://img.shields.io/badge/MacBookPro13%2C2-partially_working-yellow.svg) ![MacBookPro13,3 partially working](https://img.shields.io/badge/MacBookPro13%2C3-partially_working-yellow.svg) ![MacBookPro14,2 partially working](https://img.shields.io/badge/MacBookPro14%2C2-partially_working-yellow.svg) ![MacBookPro14,3 partially working](https://img.shields.io/badge/MacBookPro14%2C3-partially_working-yellow.svg) |
 | [Touch ID](#touch-id) | ![MacBookPro13,2 not working](https://img.shields.io/badge/MacBookPro13%2C2-not_working-red.svg) ![MacBookPro13,3 not working](https://img.shields.io/badge/MacBookPro13%2C3-not_working-red.svg) ![MacBookPro14,2 not working](https://img.shields.io/badge/MacBookPro14%2C2-not_working-red.svg) ![MacBookPro14,3 not working](https://img.shields.io/badge/MacBookPro14%2C3-not_working-red.svg) |
 | [USB](#usb) | ![all models working](https://img.shields.io/badge/all_models-working-green.svg) |
-| [Wi-Fi](#wi-fi) | ![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 not working](https://img.shields.io/badge/MacBookPro13%2C2-not_working-red.svg) ![MacBookPro13,3 not working](https://img.shields.io/badge/MacBookPro13%2C3-not_working-red.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 not working](https://img.shields.io/badge/MacBookPro14%2C2-not_working-red.svg) ![MacBookPro14,3 not working](https://img.shields.io/badge/MacBookPro14%2C3-not_working-red.svg) |
+| [Wi-Fi](#wi-fi) | ![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 not working](https://img.shields.io/badge/MacBookPro13%2C2-not_working-red.svg) ![MacBookPro13,3 not working](https://img.shields.io/badge/MacBookPro13%2C3-not_working-red.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 not working](https://img.shields.io/badge/MacBookPro14%2C2-not_working-red.svg) ![MacBookPro14,3 not working](https://img.shields.io/badge/MacBookPro14%2C3-not_working-red.svg) ![MacBookAir8,1 not working](https://img.shields.io/badge/MacBookAir8%2C1-not_working-red.svg) ![MacBookAir8,2 not working](https://img.shields.io/badge/MacBookAir8%2C2-not_working-red.svg) |
 
 ## Audio input & output
 
@@ -255,14 +255,16 @@ Works out of the box.
 ## Wi-Fi
 
 ![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 not working](https://img.shields.io/badge/MacBookPro13%2C2-not_working-red.svg) ![MacBookPro13,3 not working](https://img.shields.io/badge/MacBookPro13%2C3-not_working-red.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 not working](https://img.shields.io/badge/MacBookPro14%2C2-not_working-red.svg) ![MacBookPro14,3 not working](https://img.shields.io/badge/MacBookPro14%2C3-not_working-red.svg)
+![MacBookAir8,1 not working](https://img.shields.io/badge/MacBookAir8%2C1-not_working-red.svg)
+![MacBookAir8,2 not working](https://img.shields.io/badge/MacBookAir8%2C2-not_working-red.svg)
 
 The MacBook Pro models without Touch Bar come with a `Broadcom Limited BCM4350
 802.11ac Wireless Network Adapter` which works fine out of the box using the
 `brcmfmac` driver (ensure you got the matching firmware package installed).
 
 The MacBook Pro models with Touch Bar come with a `Broadcom Limited BCM43602
-802.11ac Wireless LAN SoC (rev 02)` which is also supported by `brcmfmac`, but
-has several issues rendering it unusable, caused by the available firmware.
+802.11ac Wireless LAN SoC (rev 02)` and Retina MacBook Air models come with a ` Broadcom Limited BCM4355`, which are also supported by `brcmfmac`, but
+have several issues rendering it unusable, caused by the available firmware.
 The issues are caused by failing country detection and are:
 * Only 2.4Ghz APs are shown
 * Connecting to an AP barely works or fails directly
@@ -271,6 +273,8 @@ According to Broadcom releasing a fixed firmware would require verification to
 ensure that it complies with regulatory limits, which is very unlikely to
 happen as it wouldn't provide enough return on investment for them (see
 https://bugzilla.kernel.org/show_bug.cgi?id=193121 for details).
+
+Re
 
 ## Misc
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ There is also a chat available via gitter for discussions:
 
 ## Current status
 
+If a section applies only to a certain subset of models, "all models" refers to that subset.
+
 | Device  | Status |
 | ------- | ------ |
 | [Audio input & output](#audio-input--output) | ![all models not working](https://img.shields.io/badge/all_models-not_working-red.svg) |
@@ -36,15 +38,15 @@ There is also a chat available via gitter for discussions:
 | [Bluetooth](#bluetooth) | ![all models working](https://img.shields.io/badge/all_models-working-green.svg) |
 | [FaceTime HD camera](#facetime-hd-camera) | ![all models working](https://img.shields.io/badge/all_models-working-green.svg) |
 | [Graphics card](#intel) (Intel) | ![all models working](https://img.shields.io/badge/all_models-working-green.svg) |
-| [Graphics card](#amd) (AMD) | ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,3 working](https://img.shields.io/badge/MacBookPro14%2C3-working-green.svg) |
+| [Graphics card](#amd) (AMD) | ![all models working](https://img.shields.io/badge/all_models-working-green.svg) |
 | [Keyboard & Touchpad](#keyboard--touchpad) | ![all models working](https://img.shields.io/badge/all_models-working-green.svg) |
 | [NVMe](#nvme) (internal SSD) | ![all models working](https://img.shields.io/badge/all_models-working-green.svg) |
 | [Screen](#screen) | ![all models working](https://img.shields.io/badge/all_models-working-green.svg) |
 | [Suspend & Hibernation](#suspend--hibernation) |![all models not working](https://img.shields.io/badge/all_models-not_working-red.svg) |
 | [System Management Controller](#system-management-controller) | ![all models working](https://img.shields.io/badge/all_models-working-green.svg) |
 | [Thunderbolt](#thunderbolt) | ![all models working](https://img.shields.io/badge/all_models-working-green.svg) |
-| [Touch Bar](#touch-bar) | ![MacBookPro13,2 partially working](https://img.shields.io/badge/MacBookPro13%2C2-partially_working-yellow.svg) ![MacBookPro13,3 partially working](https://img.shields.io/badge/MacBookPro13%2C3-partially_working-yellow.svg) ![MacBookPro14,2 partially working](https://img.shields.io/badge/MacBookPro14%2C2-partially_working-yellow.svg) ![MacBookPro14,3 partially working](https://img.shields.io/badge/MacBookPro14%2C3-partially_working-yellow.svg) |
-| [Touch ID](#touch-id) | ![MacBookPro13,2 not working](https://img.shields.io/badge/MacBookPro13%2C2-not_working-red.svg) ![MacBookPro13,3 not working](https://img.shields.io/badge/MacBookPro13%2C3-not_working-red.svg) ![MacBookPro14,2 not working](https://img.shields.io/badge/MacBookPro14%2C2-not_working-red.svg) ![MacBookPro14,3 not working](https://img.shields.io/badge/MacBookPro14%2C3-not_working-red.svg) |
+| [Touch Bar](#touch-bar) | ![all models partially working](https://img.shields.io/badge/all_models-partially_working-yellow.svg) |
+| [Touch ID](#touch-id) | ![all models not working](https://img.shields.io/badge/all_models-not_working-red.svg) |
 | [USB](#usb) | ![all models working](https://img.shields.io/badge/all_models-working-green.svg) |
 | [Wi-Fi](#wi-fi) | ![MacBookPro13,1 working](https://img.shields.io/badge/MacBookPro13%2C1-working-green.svg) ![MacBookPro13,2 not working](https://img.shields.io/badge/MacBookPro13%2C2-not_working-red.svg) ![MacBookPro13,3 not working](https://img.shields.io/badge/MacBookPro13%2C3-not_working-red.svg) ![MacBookPro14,1 working](https://img.shields.io/badge/MacBookPro14%2C1-working-green.svg) ![MacBookPro14,2 not working](https://img.shields.io/badge/MacBookPro14%2C2-not_working-red.svg) ![MacBookPro14,3 not working](https://img.shields.io/badge/MacBookPro14%2C3-not_working-red.svg) ![MacBookAir8,1 not working](https://img.shields.io/badge/MacBookAir8%2C1-not_working-red.svg) ![MacBookAir8,2 not working](https://img.shields.io/badge/MacBookAir8%2C2-not_working-red.svg) |
 


### PR DESCRIPTION
A significant amount of info about non-tMBPs is being added to this repository in the issues and dumps; however, the README and main summary don't reflect this. This updated version includes a more generalized intro as well as some specific information on other Macs. Hopefully, this should encourage additional information to be added regarding other models.