### PR TITLE
Internal audio & mic. is working for MBP13,3

### DIFF
--- a/MacBookPro13,3/arecord_CS8409
+++ b/MacBookPro13,3/arecord_CS8409
@@ -1,0 +1,7 @@
+**** List of CAPTURE Hardware Devices ****
+card 0: PCH [HDA Intel PCH], device 0: CS8409 Analog [CS8409 Analog]
+  Subdevices: 0/1
+  Subdevice #0: subdevice #0
+card 0: PCH [HDA Intel PCH], device 2: CS8409 Alt Analog [CS8409 Alt Analog]
+  Subdevices: 1/1
+  Subdevice #0: subdevice #0

--- a/MacBookPro13,3/dmesg
+++ b/MacBookPro13,3/dmesg
@@ -1,5 +1,12 @@
-[    0.000000] Linux version 4.10.11-1-ARCH (builduser@tobias) (gcc version 6.3.1 20170306 (GCC) ) #1 SMP PREEMPT Tue Apr 18 08:39:42 CEST 2017
-[    0.000000] Command line: BOOT_IMAGE=/boot/vmlinuz-linux root=UUID=686be2ff-f31a-4b2a-a8fc-bbce5dd5007a rw quiet resume=UUID=2ee83f71-45e2-4469-a84c-78942ba69036
+[    0.000000] microcode: microcode updated early to revision 0xd6, date = 2019-10-03
+[    0.000000] Linux version 5.5.11-050511-generic (kernel@kathleen) (gcc version 9.3.0 (Ubuntu 9.3.0-3ubuntu1)) #202003210837 SMP Sat Mar 21 08:40:31 UTC 2020
+[    0.000000] Command line: BOOT_IMAGE=/boot/vmlinuz-5.5.11-050511-generic root=UUID=a4e17617-b04c-4225-94aa-54075e40190a ro quiet splash vt.handoff=1
+[    0.000000] KERNEL supported cpus:
+[    0.000000]   Intel GenuineIntel
+[    0.000000]   AMD AuthenticAMD
+[    0.000000]   Hygon HygonGenuine
+[    0.000000]   Centaur CentaurHauls
+[    0.000000]   zhaoxin   Shanghai  
 [    0.000000] x86/fpu: Supporting XSAVE feature 0x001: 'x87 floating point registers'
 [    0.000000] x86/fpu: Supporting XSAVE feature 0x002: 'SSE registers'
 [    0.000000] x86/fpu: Supporting XSAVE feature 0x004: 'AVX registers'
@@ -9,21 +16,20 @@
 [    0.000000] x86/fpu: xstate_offset[3]:  832, xstate_sizes[3]:   64
 [    0.000000] x86/fpu: xstate_offset[4]:  896, xstate_sizes[4]:   64
 [    0.000000] x86/fpu: Enabled xstate features 0x1f, context size is 960 bytes, using 'compacted' format.
-[    0.000000] e820: BIOS-provided physical RAM map:
+[    0.000000] BIOS-provided physical RAM map:
 [    0.000000] BIOS-e820: [mem 0x0000000000000000-0x0000000000057fff] usable
 [    0.000000] BIOS-e820: [mem 0x0000000000058000-0x0000000000058fff] reserved
 [    0.000000] BIOS-e820: [mem 0x0000000000059000-0x000000000009dfff] usable
 [    0.000000] BIOS-e820: [mem 0x000000000009e000-0x00000000000fffff] reserved
-[    0.000000] BIOS-e820: [mem 0x0000000000100000-0x0000000074034fff] usable
-[    0.000000] BIOS-e820: [mem 0x0000000074035000-0x0000000074386fff] reserved
-[    0.000000] BIOS-e820: [mem 0x0000000074387000-0x0000000074e17fff] usable
-[    0.000000] BIOS-e820: [mem 0x0000000074e18000-0x0000000074e18fff] ACPI NVS
-[    0.000000] BIOS-e820: [mem 0x0000000074e19000-0x0000000074e62fff] reserved
-[    0.000000] BIOS-e820: [mem 0x0000000074e63000-0x000000007507dfff] usable
+[    0.000000] BIOS-e820: [mem 0x0000000000100000-0x0000000074021fff] usable
+[    0.000000] BIOS-e820: [mem 0x0000000074022000-0x0000000074373fff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000074374000-0x0000000074e04fff] usable
+[    0.000000] BIOS-e820: [mem 0x0000000074e05000-0x0000000074e05fff] ACPI NVS
+[    0.000000] BIOS-e820: [mem 0x0000000074e06000-0x0000000074e4ffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000074e50000-0x000000007507dfff] usable
 [    0.000000] BIOS-e820: [mem 0x000000007507e000-0x000000007507efff] reserved
 [    0.000000] BIOS-e820: [mem 0x000000007507f000-0x000000007ac7efff] usable
-[    0.000000] BIOS-e820: [mem 0x000000007ac7f000-0x000000007aceefff] type 20
-[    0.000000] BIOS-e820: [mem 0x000000007acef000-0x000000007af4efff] reserved
+[    0.000000] BIOS-e820: [mem 0x000000007ac7f000-0x000000007af4efff] reserved
 [    0.000000] BIOS-e820: [mem 0x000000007af4f000-0x000000007af9efff] ACPI NVS
 [    0.000000] BIOS-e820: [mem 0x000000007af9f000-0x000000007affefff] ACPI data
 [    0.000000] BIOS-e820: [mem 0x000000007afff000-0x000000007affffff] usable
@@ -34,1332 +40,1385 @@
 [    0.000000] BIOS-e820: [mem 0x00000000ff939000-0x00000000ff968fff] reserved
 [    0.000000] BIOS-e820: [mem 0x0000000100000000-0x000000047effffff] usable
 [    0.000000] NX (Execute Disable) protection: active
+[    0.000000] e820: update [mem 0x7397c018-0x7398a857] usable ==> usable
+[    0.000000] e820: update [mem 0x7397c018-0x7398a857] usable ==> usable
+[    0.000000] e820: update [mem 0x7396a018-0x7397b70d] usable ==> usable
+[    0.000000] e820: update [mem 0x7396a018-0x7397b70d] usable ==> usable
+[    0.000000] extended physical RAM map:
+[    0.000000] reserve setup_data: [mem 0x0000000000000000-0x0000000000057fff] usable
+[    0.000000] reserve setup_data: [mem 0x0000000000058000-0x0000000000058fff] reserved
+[    0.000000] reserve setup_data: [mem 0x0000000000059000-0x000000000009dfff] usable
+[    0.000000] reserve setup_data: [mem 0x000000000009e000-0x00000000000fffff] reserved
+[    0.000000] reserve setup_data: [mem 0x0000000000100000-0x000000007396a017] usable
+[    0.000000] reserve setup_data: [mem 0x000000007396a018-0x000000007397b70d] usable
+[    0.000000] reserve setup_data: [mem 0x000000007397b70e-0x000000007397c017] usable
+[    0.000000] reserve setup_data: [mem 0x000000007397c018-0x000000007398a857] usable
+[    0.000000] reserve setup_data: [mem 0x000000007398a858-0x0000000074021fff] usable
+[    0.000000] reserve setup_data: [mem 0x0000000074022000-0x0000000074373fff] reserved
+[    0.000000] reserve setup_data: [mem 0x0000000074374000-0x0000000074e04fff] usable
+[    0.000000] reserve setup_data: [mem 0x0000000074e05000-0x0000000074e05fff] ACPI NVS
+[    0.000000] reserve setup_data: [mem 0x0000000074e06000-0x0000000074e4ffff] reserved
+[    0.000000] reserve setup_data: [mem 0x0000000074e50000-0x000000007507dfff] usable
+[    0.000000] reserve setup_data: [mem 0x000000007507e000-0x000000007507efff] reserved
+[    0.000000] reserve setup_data: [mem 0x000000007507f000-0x000000007ac7efff] usable
+[    0.000000] reserve setup_data: [mem 0x000000007ac7f000-0x000000007af4efff] reserved
+[    0.000000] reserve setup_data: [mem 0x000000007af4f000-0x000000007af9efff] ACPI NVS
+[    0.000000] reserve setup_data: [mem 0x000000007af9f000-0x000000007affefff] ACPI data
+[    0.000000] reserve setup_data: [mem 0x000000007afff000-0x000000007affffff] usable
+[    0.000000] reserve setup_data: [mem 0x000000007b000000-0x000000007fffffff] reserved
+[    0.000000] reserve setup_data: [mem 0x00000000e00fa000-0x00000000e00fafff] reserved
+[    0.000000] reserve setup_data: [mem 0x00000000e00fd000-0x00000000e00fdfff] reserved
+[    0.000000] reserve setup_data: [mem 0x00000000fe000000-0x00000000fe010fff] reserved
+[    0.000000] reserve setup_data: [mem 0x00000000ff939000-0x00000000ff968fff] reserved
+[    0.000000] reserve setup_data: [mem 0x0000000100000000-0x000000047effffff] usable
 [    0.000000] efi: EFI v2.40 by Apple
 [    0.000000] efi:  ACPI=0x7affe000  ACPI 2.0=0x7affe014  SMBIOS=0x7aeff000  SMBIOS 3.0=0x7aefd000 
 [    0.000000] SMBIOS 3.0.0 present.
-[    0.000000] DMI: Apple Inc. MacBookPro13,3/Mac-A5C67F76ED83108C, BIOS MBP133.88Z.0226.B15.1702161827 02/16/2017
-[    0.000000] e820: update [mem 0x00000000-0x00000fff] usable ==> reserved
-[    0.000000] e820: remove [mem 0x000a0000-0x000fffff] usable
-[    0.000000] e820: last_pfn = 0x47f000 max_arch_pfn = 0x400000000
-[    0.000000] MTRR default type: write-back
-[    0.000000] MTRR fixed ranges enabled:
-[    0.000000]   00000-9FFFF write-back
-[    0.000000]   A0000-BFFFF uncachable
-[    0.000000]   C0000-DFFFF write-protect
-[    0.000000]   E0000-FFFFF uncachable
-[    0.000000] MTRR variable ranges enabled:
-[    0.000000]   0 base 0080000000 mask 7F80000000 uncachable
-[    0.000000]   1 base 007C000000 mask 7FFC000000 uncachable
-[    0.000000]   2 base 007B000000 mask 7FFF000000 uncachable
-[    0.000000]   3 base 4000000000 mask 4000000000 uncachable
-[    0.000000]   4 disabled
-[    0.000000]   5 disabled
-[    0.000000]   6 disabled
-[    0.000000]   7 disabled
-[    0.000000]   8 disabled
-[    0.000000]   9 disabled
-[    0.000000] x86/PAT: Configuration [0-7]: WB  WC  UC- UC  WB  WC  UC- WT  
-[    0.000000] e820: last_pfn = 0x7b000 max_arch_pfn = 0x400000000
-[    0.000000] Scanning 1 areas for low memory corruption
-[    0.000000] Base memory trampoline at [ffff880000098000] 98000 size 24576
-[    0.000000] Using GB pages for direct mapping
-[    0.000000] BRK [0x02d5f000, 0x02d5ffff] PGTABLE
-[    0.000000] BRK [0x02d60000, 0x02d60fff] PGTABLE
-[    0.000000] BRK [0x02d61000, 0x02d61fff] PGTABLE
-[    0.000000] BRK [0x02d62000, 0x02d62fff] PGTABLE
-[    0.000000] BRK [0x02d63000, 0x02d63fff] PGTABLE
-[    0.000000] BRK [0x02d64000, 0x02d64fff] PGTABLE
-[    0.000000] RAMDISK: [mem 0x3752f000-0x37a8efff]
-[    0.000000] ACPI: Early table checksum verification disabled
-[    0.000000] ACPI: RSDP 0x000000007AFFE014 000024 (v02 APPLE )
-[    0.000000] ACPI: XSDT 0x000000007AFC3188 0000D4 (v01 APPLE  Apple00  00000000      01000013)
-[    0.000000] ACPI: FACP 0x000000007AFF8000 0000F4 (v05 APPLE  Apple00  00000000 Loki 0000005F)
-[    0.000000] ACPI: DSDT 0x000000007AFEB000 00869F (v02 APPLE  MacBookP 00150001 INTL 20140424)
-[    0.000000] ACPI: FACS 0x000000007AF9B000 000040
-[    0.000000] ACPI: UEFI 0x000000007AF9D000 000042 (v01 INTEL  EDK2     00000002      01000013)
-[    0.000000] ACPI: ECDT 0x000000007AFFA000 000053 (v01 APPLE  Apple00  00000001 Loki 0000005F)
-[    0.000000] ACPI: HPET 0x000000007AFF7000 000038 (v01 APPLE  Apple00  00000001 Loki 0000005F)
-[    0.000000] ACPI: APIC 0x000000007AFF6000 0000BC (v02 APPLE  Apple00  00000001 Loki 0000005F)
-[    0.000000] ACPI: MCFG 0x000000007AFF5000 00003C (v01 APPLE  Apple00  00000001 Loki 0000005F)
-[    0.000000] ACPI: SBST 0x000000007AFF4000 000030 (v01 APPLE  Apple00  00000001 Loki 0000005F)
-[    0.000000] ACPI: SSDT 0x000000007AFEA000 000024 (v01 APPLE  SmcDppt  00001000 INTL 20140424)
-[    0.000000] ACPI: SSDT 0x000000007AFE9000 0007FD (v02 APPLE  PEG0GFX0 00001000 INTL 20140424)
-[    0.000000] ACPI: SSDT 0x000000007AFE8000 000024 (v01 APPLE  PEG0SSD0 00001000 INTL 20140424)
-[    0.000000] ACPI: SSDT 0x000000007AFE5000 000031 (v01 APPLE  SsdtS3   00001000 INTL 20140424)
-[    0.000000] ACPI: SSDT 0x000000007AFE4000 0000DD (v01 APPLE  SataAhci 00001000 INTL 20140424)
-[    0.000000] ACPI: SSDT 0x000000007AFE3000 0000B8 (v01 APPLE  Sdxc     00001000 INTL 20140424)
-[    0.000000] ACPI: SSDT 0x000000007AFCB000 00AFEE (v02 APPLE  TbtPEG12 00001000 INTL 20140424)
-[    0.000000] ACPI: SSDT 0x000000007AFCA000 000BF4 (v02 APPLE  Xhci     00001000 INTL 20140424)
-[    0.000000] ACPI: SSDT 0x000000007AFC9000 0005AF (v02 PmRef  Cpu0Ist  00003000 INTL 20140424)
-[    0.000000] ACPI: SSDT 0x000000007AFC8000 0005AA (v02 PmRef  ApIst    00003000 INTL 20140424)
-[    0.000000] ACPI: SSDT 0x000000007AFC7000 000295 (v02 PmRef  Cpu0Cst  00003001 INTL 20140424)
-[    0.000000] ACPI: SSDT 0x000000007AFC6000 000119 (v02 PmRef  ApCst    00003000 INTL 20140424)
-[    0.000000] ACPI: SSDT 0x000000007AFC5000 000EEF (v02 CpuRef CpuSsdt  00003000 INTL 20140424)
-[    0.000000] ACPI: DMAR 0x000000007AFC4000 000160 (v01 APPLE  SKL      00000001 INTL 00000001)
-[    0.000000] ACPI: VFCT 0x000000007AFB4000 00EC84 (v01 APPLE  Apple00  00000001 AMD  31504F47)
-[    0.000000] ACPI: DMI detected to setup _OSI("Darwin"): Apple hardware
-[    0.000000] ACPI: Local APIC address 0xfee00000
-[    0.000000] No NUMA configuration found
-[    0.000000] Faking a node at [mem 0x0000000000000000-0x000000047effffff]
-[    0.000000] NODE_DATA(0) allocated [mem 0x47eff6000-0x47effafff]
-[    0.000000] Zone ranges:
-[    0.000000]   DMA      [mem 0x0000000000001000-0x0000000000ffffff]
-[    0.000000]   DMA32    [mem 0x0000000001000000-0x00000000ffffffff]
-[    0.000000]   Normal   [mem 0x0000000100000000-0x000000047effffff]
-[    0.000000]   Device   empty
-[    0.000000] Movable zone start for each node
-[    0.000000] Early memory node ranges
-[    0.000000]   node   0: [mem 0x0000000000001000-0x0000000000057fff]
-[    0.000000]   node   0: [mem 0x0000000000059000-0x000000000009dfff]
-[    0.000000]   node   0: [mem 0x0000000000100000-0x0000000074034fff]
-[    0.000000]   node   0: [mem 0x0000000074387000-0x0000000074e17fff]
-[    0.000000]   node   0: [mem 0x0000000074e63000-0x000000007507dfff]
-[    0.000000]   node   0: [mem 0x000000007507f000-0x000000007ac7efff]
-[    0.000000]   node   0: [mem 0x000000007afff000-0x000000007affffff]
-[    0.000000]   node   0: [mem 0x0000000100000000-0x000000047effffff]
-[    0.000000] Initmem setup node 0 [mem 0x0000000000001000-0x000000047effffff]
-[    0.000000] On node 0 totalpages: 4167806
-[    0.000000]   DMA zone: 64 pages used for memmap
-[    0.000000]   DMA zone: 22 pages reserved
-[    0.000000]   DMA zone: 3996 pages, LIFO batch:0
-[    0.000000]   DMA32 zone: 7780 pages used for memmap
-[    0.000000]   DMA32 zone: 497890 pages, LIFO batch:31
-[    0.000000]   Normal zone: 57280 pages used for memmap
-[    0.000000]   Normal zone: 3665920 pages, LIFO batch:31
-[    0.000000] ACPI: PM-Timer IO Port: 0x1808
-[    0.000000] ACPI: Local APIC address 0xfee00000
-[    0.000000] ACPI: LAPIC_NMI (acpi_id[0x01] high edge lint[0x1])
-[    0.000000] ACPI: LAPIC_NMI (acpi_id[0x02] high edge lint[0x1])
-[    0.000000] ACPI: LAPIC_NMI (acpi_id[0x03] high edge lint[0x1])
-[    0.000000] ACPI: LAPIC_NMI (acpi_id[0x04] high edge lint[0x1])
-[    0.000000] ACPI: LAPIC_NMI (acpi_id[0x05] high edge lint[0x1])
-[    0.000000] ACPI: LAPIC_NMI (acpi_id[0x06] high edge lint[0x1])
-[    0.000000] ACPI: LAPIC_NMI (acpi_id[0x07] high edge lint[0x1])
-[    0.000000] ACPI: LAPIC_NMI (acpi_id[0x08] high edge lint[0x1])
-[    0.000000] IOAPIC[0]: apic_id 2, version 32, address 0xfec00000, GSI 0-23
-[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 0 global_irq 2 dfl dfl)
-[    0.000000] ACPI: INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
-[    0.000000] ACPI: IRQ0 used by override.
-[    0.000000] ACPI: IRQ9 used by override.
-[    0.000000] Using ACPI (MADT) for SMP configuration information
-[    0.000000] ACPI: HPET id: 0x8086a201 base: 0xfed00000
-[    0.000000] smpboot: Allowing 8 CPUs, 0 hotplug CPUs
-[    0.000000] PM: Registered nosave memory: [mem 0x00000000-0x00000fff]
-[    0.000000] PM: Registered nosave memory: [mem 0x00058000-0x00058fff]
-[    0.000000] PM: Registered nosave memory: [mem 0x0009e000-0x000fffff]
-[    0.000000] PM: Registered nosave memory: [mem 0x74035000-0x74386fff]
-[    0.000000] PM: Registered nosave memory: [mem 0x74e18000-0x74e18fff]
-[    0.000000] PM: Registered nosave memory: [mem 0x74e19000-0x74e62fff]
-[    0.000000] PM: Registered nosave memory: [mem 0x7507e000-0x7507efff]
-[    0.000000] PM: Registered nosave memory: [mem 0x7ac7f000-0x7aceefff]
-[    0.000000] PM: Registered nosave memory: [mem 0x7acef000-0x7af4efff]
-[    0.000000] PM: Registered nosave memory: [mem 0x7af4f000-0x7af9efff]
-[    0.000000] PM: Registered nosave memory: [mem 0x7af9f000-0x7affefff]
-[    0.000000] PM: Registered nosave memory: [mem 0x7b000000-0x7fffffff]
-[    0.000000] PM: Registered nosave memory: [mem 0x80000000-0xe00f9fff]
-[    0.000000] PM: Registered nosave memory: [mem 0xe00fa000-0xe00fafff]
-[    0.000000] PM: Registered nosave memory: [mem 0xe00fb000-0xe00fcfff]
-[    0.000000] PM: Registered nosave memory: [mem 0xe00fd000-0xe00fdfff]
-[    0.000000] PM: Registered nosave memory: [mem 0xe00fe000-0xfdffffff]
-[    0.000000] PM: Registered nosave memory: [mem 0xfe000000-0xfe010fff]
-[    0.000000] PM: Registered nosave memory: [mem 0xfe011000-0xff938fff]
-[    0.000000] PM: Registered nosave memory: [mem 0xff939000-0xff968fff]
-[    0.000000] PM: Registered nosave memory: [mem 0xff969000-0xffffffff]
-[    0.000000] e820: [mem 0x80000000-0xe00f9fff] available for PCI devices
-[    0.000000] Booting paravirtualized kernel on bare hardware
-[    0.000000] clocksource: refined-jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 6370452778343963 ns
-[    0.000000] setup_percpu: NR_CPUS:128 nr_cpumask_bits:128 nr_cpu_ids:8 nr_node_ids:1
-[    0.000000] percpu: Embedded 35 pages/cpu @ffff88047ec00000 s103768 r8192 d31400 u262144
-[    0.000000] pcpu-alloc: s103768 r8192 d31400 u262144 alloc=1*2097152
-[    0.000000] pcpu-alloc: [0] 0 1 2 3 4 5 6 7 
-[    0.000000] Built 1 zonelists in Node order, mobility grouping on.  Total pages: 4102660
-[    0.000000] Policy zone: Normal
-[    0.000000] Kernel command line: BOOT_IMAGE=/boot/vmlinuz-linux root=UUID=686be2ff-f31a-4b2a-a8fc-bbce5dd5007a rw quiet resume=UUID=2ee83f71-45e2-4469-a84c-78942ba69036
-[    0.000000] PID hash table entries: 4096 (order: 3, 32768 bytes)
-[    0.000000] Calgary: detecting Calgary via BIOS EBDA area
-[    0.000000] Calgary: Unable to locate Rio Grande table in EBDA - bailing!
-[    0.000000] Memory: 16174300K/16671224K available (6367K kernel code, 1090K rwdata, 1984K rodata, 1292K init, 1032K bss, 496924K reserved, 0K cma-reserved)
-[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=8, Nodes=1
-[    0.000000] Preemptible hierarchical RCU implementation.
-[    0.000000] 	Build-time adjustment of leaf fanout to 64.
-[    0.000000] 	RCU restricting CPUs from NR_CPUS=128 to nr_cpu_ids=8.
-[    0.000000] RCU: Adjusting geometry for rcu_fanout_leaf=64, nr_cpu_ids=8
-[    0.000000] NR_IRQS:8448 nr_irqs:488 16
-[    0.000000] Console: colour dummy device 80x25
-[    0.000000] console [tty0] enabled
-[    0.000000] clocksource: hpet: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 79635855245 ns
-[    0.000000] hpet clockevent registered
-[    0.000000] tsc: Detected 2600.000 MHz processor
-[    0.000019] Calibrating delay loop (skipped), value calculated using timer frequency.. 5186.00 BogoMIPS (lpj=8640000)
-[    0.000021] pid_max: default: 32768 minimum: 301
-[    0.000028] ACPI: Core revision 20160930
-[    0.010896] ACPI: 14 ACPI AML tables successfully acquired and loaded
-[    0.017571] Security Framework initialized
-[    0.017571] Yama: becoming mindful.
-[    0.018114] Dentry cache hash table entries: 2097152 (order: 12, 16777216 bytes)
-[    0.020279] Inode-cache hash table entries: 1048576 (order: 11, 8388608 bytes)
-[    0.021222] Mount-cache hash table entries: 32768 (order: 6, 262144 bytes)
-[    0.021231] Mountpoint-cache hash table entries: 32768 (order: 6, 262144 bytes)
-[    0.021415] CPU: Physical Processor ID: 0
-[    0.021415] CPU: Processor Core ID: 0
-[    0.021418] ENERGY_PERF_BIAS: Set to 'normal', was 'performance'
-[    0.021418] ENERGY_PERF_BIAS: View and update with x86_energy_perf_policy(8)
-[    0.021422] mce: CPU supports 10 MCE banks
-[    0.021429] CPU0: Thermal monitoring enabled (TM1)
-[    0.021443] process: using mwait in idle threads
-[    0.021445] Last level iTLB entries: 4KB 64, 2MB 8, 4MB 8
-[    0.021446] Last level dTLB entries: 4KB 64, 2MB 0, 4MB 0, 1GB 4
-[    0.021516] Freeing SMP alternatives memory: 24K
-[    0.024642] ftrace: allocating 25115 entries in 99 pages
-[    0.033367] smpboot: Max logical packages: 2
-[    0.033373] DMAR: Host address width 39
-[    0.033374] DMAR: DRHD base: 0x000000fed90000 flags: 0x0
-[    0.033377] DMAR: dmar0: reg_base_addr fed90000 ver 1:0 cap 1c0000c40660462 ecap 7e3ff0501e
-[    0.033378] DMAR: DRHD base: 0x000000fed91000 flags: 0x1
-[    0.033380] DMAR: dmar1: reg_base_addr fed91000 ver 1:0 cap d2008c40660462 ecap f050da
-[    0.033381] DMAR: RMRR base: 0x0000007b800000 end: 0x0000007fffffff
-[    0.033382] DMAR: ANDD device: 1 name: \_SB.PCI0.I2C0
-[    0.033382] DMAR: ANDD device: 7 name: \_SB.PCI0.SPI0
-[    0.033382] DMAR: ANDD device: 8 name: \_SB.PCI0.SPI1
-[    0.033383] DMAR: ANDD device: 9 name: \_SB.PCI0.UA00
-[    0.033383] DMAR: ANDD device: a name: \_SB.PCI0.UA01
-[    0.033383] DMAR: ANDD device: b name: \_SB.PCI0.UA02
-[    0.033384] DMAR-IR: IOAPIC id 2 under DRHD base  0xfed91000 IOMMU 1
-[    0.033385] DMAR-IR: HPET id 0 under DRHD base 0xfed91000
-[    0.033385] DMAR-IR: Queued invalidation will be enabled to support x2apic and Intr-remapping.
-[    0.033797] DMAR-IR: Enabled IRQ remapping in x2apic mode
-[    0.033797] x2apic enabled
-[    0.033807] Switched APIC routing to cluster x2apic.
-[    0.034844] ..TIMER: vector=0x30 apic1=0 pin1=2 apic2=-1 pin2=-1
-[    0.067863] TSC deadline timer enabled
-[    0.067868] smpboot: CPU0: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz (family: 0x6, model: 0x5e, stepping: 0x3)
-[    0.077885] Performance Events: PEBS fmt3+, Skylake events, 32-deep LBR, full-width counters, Intel PMU driver.
-[    0.077940] ... version:                4
-[    0.077941] ... bit width:              48
-[    0.077941] ... generic registers:      4
-[    0.077941] ... value mask:             0000ffffffffffff
-[    0.077942] ... max period:             00007fffffffffff
-[    0.077942] ... fixed-purpose events:   3
-[    0.077942] ... event mask:             000000070000000f
-[    0.101370] NMI watchdog: enabled on all CPUs, permanently consumes one hw-PMU counter.
-[    0.107925] smp: Bringing up secondary CPUs ...
-[    0.134640] x86: Booting SMP configuration:
-[    0.134643] .... node  #0, CPUs:      #1 #2 #3 #4 #5 #6 #7
-[    0.878323] smp: Brought up 1 node, 8 CPUs
-[    0.878324] smpboot: Total of 8 processors activated (41497.77 BogoMIPS)
-[    0.884502] devtmpfs: initialized
-[    0.884543] x86/mm: Memory block size: 128MB
-[    0.886580] PM: Registering ACPI NVS region [mem 0x74e18000-0x74e18fff] (4096 bytes)
-[    0.886580] PM: Registering ACPI NVS region [mem 0x7af4f000-0x7af9efff] (327680 bytes)
-[    0.886623] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 6370867519511994 ns
-[    0.886631] futex hash table entries: 2048 (order: 5, 131072 bytes)
-[    0.886671] pinctrl core: initialized pinctrl subsystem
-[    0.886785] RTC time: 20:14:30, date: 04/29/17
-[    0.886842] NET: Registered protocol family 16
-[    0.900810] cpuidle: using governor ladder
-[    0.924164] cpuidle: using governor menu
-[    0.924167] PCCT header not found.
-[    0.924210] ACPI FADT declares the system doesn't support PCIe ASPM, so disable it
-[    0.924210] ACPI: bus type PCI registered
-[    0.924211] acpiphp: ACPI Hot Plug PCI Controller Driver version: 0.5
-[    0.924274] PCI: MMCONFIG for domain 0000 [bus 00-ff] at [mem 0xe0000000-0xefffffff] (base 0xe0000000)
-[    0.924300] PCI: not using MMCONFIG
-[    0.924301] PCI: Using configuration type 1 for base access
-[    0.944288] HugeTLB registered 1 GB page size, pre-allocated 0 pages
-[    0.944288] HugeTLB registered 2 MB page size, pre-allocated 0 pages
-[    0.944465] ACPI: Disabled all _OSI OS vendors
-[    0.944466] ACPI: Added _OSI(Module Device)
-[    0.944467] ACPI: Added _OSI(Processor Device)
-[    0.944467] ACPI: Added _OSI(3.0 _SCP Extensions)
-[    0.944468] ACPI: Added _OSI(Processor Aggregator Device)
-[    0.944471] ACPI: Added _OSI(Darwin)
-[    0.944476] ACPI : EC: EC started
-[    1.034478] ACPI: \: Used as first EC
-[    1.034479] ACPI: \: GPE=0x7, EC_CMD/EC_SC=0x66, EC_DATA=0x62
-[    1.034480] ACPI: \: Used as boot ECDT EC to handle transactions
-[    1.038743] ACPI: BIOS _OSI(Darwin) query honored via DMI
-[    1.041653] ACPI: [Firmware Bug]: BIOS _OSI(Linux) query ignored
-[    1.042102] ACPI: Dynamic OEM Table Load:
-[    1.042181] ACPI Error: Method parse/execution failed [\_PR.CPU0.GCAP] (Node ffff88046e11e0c8), AE_ALREADY_EXISTS (20160930/psparse-543)
-[    1.042195] ACPI Error: Method parse/execution failed [\_PR.CPU0._OSC] (Node ffff88046e11e5c8), AE_ALREADY_EXISTS (20160930/psparse-543)
-[    1.042201] ACPI: Marking method _OSC as Serialized because of AE_ALREADY_EXISTS error
-[    1.042407] ACPI Error: [\_SB_.OSCP] Namespace lookup failure, AE_NOT_FOUND (20160930/psargs-359)
-[    1.042412] ACPI Error: Method parse/execution failed [\_PR.CPU1.GCAP] (Node ffff88046e11e2f8), AE_NOT_FOUND (20160930/psparse-543)
-[    1.042418] ACPI Error: Method parse/execution failed [\_PR.CPU1._OSC] (Node ffff88046e11ec58), AE_NOT_FOUND (20160930/psparse-543)
-[    1.042609] ACPI Error: [\_SB_.OSCP] Namespace lookup failure, AE_NOT_FOUND (20160930/psargs-359)
-[    1.042613] ACPI Error: Method parse/execution failed [\_PR.CPU2.GCAP] (Node ffff88046e11e910), AE_NOT_FOUND (20160930/psparse-543)
-[    1.042618] ACPI Error: Method parse/execution failed [\_PR.CPU2._OSC] (Node ffff88046e11e6b8), AE_NOT_FOUND (20160930/psparse-543)
-[    1.042801] ACPI Error: [\_SB_.OSCP] Namespace lookup failure, AE_NOT_FOUND (20160930/psargs-359)
-[    1.042805] ACPI Error: Method parse/execution failed [\_PR.CPU3.GCAP] (Node ffff88046e11e7d0), AE_NOT_FOUND (20160930/psparse-543)
-[    1.042810] ACPI Error: Method parse/execution failed [\_PR.CPU3._OSC] (Node ffff88046e11e348), AE_NOT_FOUND (20160930/psparse-543)
-[    1.042994] ACPI Error: [\_SB_.OSCP] Namespace lookup failure, AE_NOT_FOUND (20160930/psargs-359)
-[    1.042998] ACPI Error: Method parse/execution failed [\_PR.CPU4.GCAP] (Node ffff88046e11f500), AE_NOT_FOUND (20160930/psparse-543)
-[    1.043005] ACPI Error: Method parse/execution failed [\_PR.CPU4._OSC] (Node ffff88046e11fd70), AE_NOT_FOUND (20160930/psparse-543)
-[    1.043190] ACPI Error: [\_SB_.OSCP] Namespace lookup failure, AE_NOT_FOUND (20160930/psargs-359)
-[    1.043196] ACPI Error: Method parse/execution failed [\_PR.CPU5.GCAP] (Node ffff88046e11f488), AE_NOT_FOUND (20160930/psparse-543)
-[    1.043203] ACPI Error: Method parse/execution failed [\_PR.CPU5._OSC] (Node ffff88046e11fe38), AE_NOT_FOUND (20160930/psparse-543)
-[    1.043388] ACPI Error: [\_SB_.OSCP] Namespace lookup failure, AE_NOT_FOUND (20160930/psargs-359)
-[    1.043393] ACPI Error: Method parse/execution failed [\_PR.CPU6.GCAP] (Node ffff88046e11f9d8), AE_NOT_FOUND (20160930/psparse-543)
-[    1.043400] ACPI Error: Method parse/execution failed [\_PR.CPU6._OSC] (Node ffff88046e11f578), AE_NOT_FOUND (20160930/psparse-543)
-[    1.043584] ACPI Error: [\_SB_.OSCP] Namespace lookup failure, AE_NOT_FOUND (20160930/psargs-359)
-[    1.043590] ACPI Error: Method parse/execution failed [\_PR.CPU7.GCAP] (Node ffff88046e11fe10), AE_NOT_FOUND (20160930/psparse-543)
-[    1.043597] ACPI Error: Method parse/execution failed [\_PR.CPU7._OSC] (Node ffff88046e11f1e0), AE_NOT_FOUND (20160930/psparse-543)
-[    1.044137] ACPI: Dynamic OEM Table Load:
-[    1.044143] ACPI Error: Method parse/execution failed [\_PR.CPU0.GCAP] (Node ffff88046e11e0c8), AE_ALREADY_EXISTS (20160930/psparse-543)
-[    1.044158] ACPI Error: Method parse/execution failed [\_PR.CPU0._PDC] (Node ffff88046e11e870), AE_ALREADY_EXISTS (20160930/psparse-543)
-[    1.044165] ACPI: Marking method _PDC as Serialized because of AE_ALREADY_EXISTS error
-[    1.044453] ACPI: Dynamic OEM Table Load:
-[    1.044460] ACPI Error: Method parse/execution failed [\_PR.CPU1.APPT] (Node ffff88046e11e9b0), AE_ALREADY_EXISTS (20160930/psparse-543)
-[    1.044472] ACPI Error: Method parse/execution failed [\_PR.CPU1.GCAP] (Node ffff88046e11e2f8), AE_ALREADY_EXISTS (20160930/psparse-543)
-[    1.044479] ACPI Error: Method parse/execution failed [\_PR.CPU1._PDC] (Node ffff88046e11e000), AE_ALREADY_EXISTS (20160930/psparse-543)
-[    1.044486] ACPI: Marking method _PDC as Serialized because of AE_ALREADY_EXISTS error
-[    1.044705] ACPI Error: [\_SB_.OSCP] Namespace lookup failure, AE_NOT_FOUND (20160930/psargs-359)
-[    1.044711] ACPI Error: Method parse/execution failed [\_PR.CPU2.GCAP] (Node ffff88046e11e910), AE_NOT_FOUND (20160930/psparse-543)
-[    1.044718] ACPI Error: Method parse/execution failed [\_PR.CPU2._PDC] (Node ffff88046e11ecf8), AE_NOT_FOUND (20160930/psparse-543)
-[    1.044938] ACPI Error: [\_SB_.OSCP] Namespace lookup failure, AE_NOT_FOUND (20160930/psargs-359)
-[    1.044944] ACPI Error: Method parse/execution failed [\_PR.CPU3.GCAP] (Node ffff88046e11e7d0), AE_NOT_FOUND (20160930/psparse-543)
-[    1.044951] ACPI Error: Method parse/execution failed [\_PR.CPU3._PDC] (Node ffff88046e11e190), AE_NOT_FOUND (20160930/psparse-543)
-[    1.045170] ACPI Error: [\_SB_.OSCP] Namespace lookup failure, AE_NOT_FOUND (20160930/psargs-359)
-[    1.045176] ACPI Error: Method parse/execution failed [\_PR.CPU4.GCAP] (Node ffff88046e11f500), AE_NOT_FOUND (20160930/psparse-543)
-[    1.045183] ACPI Error: Method parse/execution failed [\_PR.CPU4._PDC] (Node ffff88046e11efc8), AE_NOT_FOUND (20160930/psparse-543)
-[    1.045401] ACPI Error: [\_SB_.OSCP] Namespace lookup failure, AE_NOT_FOUND (20160930/psargs-359)
-[    1.045407] ACPI Error: Method parse/execution failed [\_PR.CPU5.GCAP] (Node ffff88046e11f488), AE_NOT_FOUND (20160930/psparse-543)
-[    1.045414] ACPI Error: Method parse/execution failed [\_PR.CPU5._PDC] (Node ffff88046e11faf0), AE_NOT_FOUND (20160930/psparse-543)
-[    1.045631] ACPI Error: [\_SB_.OSCP] Namespace lookup failure, AE_NOT_FOUND (20160930/psargs-359)
-[    1.045637] ACPI Error: Method parse/execution failed [\_PR.CPU6.GCAP] (Node ffff88046e11f9d8), AE_NOT_FOUND (20160930/psparse-543)
-[    1.045643] ACPI Error: Method parse/execution failed [\_PR.CPU6._PDC] (Node ffff88046e11ff78), AE_NOT_FOUND (20160930/psparse-543)
-[    1.045861] ACPI Error: [\_SB_.OSCP] Namespace lookup failure, AE_NOT_FOUND (20160930/psargs-359)
-[    1.045866] ACPI Error: Method parse/execution failed [\_PR.CPU7.GCAP] (Node ffff88046e11fe10), AE_NOT_FOUND (20160930/psparse-543)
-[    1.045873] ACPI Error: Method parse/execution failed [\_PR.CPU7._PDC] (Node ffff88046e11ff50), AE_NOT_FOUND (20160930/psparse-543)
-[    1.046239] ACPI : EC: EC stopped
-[    1.046240] ACPI : EC: EC started
-[    1.104410] ACPI: \_SB_.PCI0.LPCB.EC__: Used as first EC
-[    1.104411] ACPI: \_SB_.PCI0.LPCB.EC__: GPE=0x7, EC_CMD/EC_SC=0x66, EC_DATA=0x62
-[    1.104412] ACPI: \_SB_.PCI0.LPCB.EC__: Used as boot DSDT EC to handle transactions
-[    1.104413] ACPI: Interpreter enabled
-[    1.104432] ACPI: (supports S0 S3 S4 S5)
-[    1.104432] ACPI: Using IOAPIC for interrupt routing
-[    1.104450] PCI: MMCONFIG for domain 0000 [bus 00-ff] at [mem 0xe0000000-0xefffffff] (base 0xe0000000)
-[    1.104857] PCI: MMCONFIG at [mem 0xe0000000-0xefffffff] reserved in ACPI motherboard resources
-[    1.104867] PCI: Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
-[    1.211566] ACPI: PCI Root Bridge [PCI0] (domain 0000 [bus 00-ff])
-[    1.211569] acpi PNP0A08:00: _OSC: OS assumes control of [PCIeHotplug SHPCHotplug AER PCIeCapability]
-[    1.211873] PCI host bridge to bus 0000:00
-[    1.211875] pci_bus 0000:00: root bus resource [io  0x0000-0x0cf7 window]
-[    1.211876] pci_bus 0000:00: root bus resource [io  0x0d00-0xffff window]
-[    1.211877] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
-[    1.211877] pci_bus 0000:00: root bus resource [mem 0x000c0000-0x000c3fff window]
-[    1.211878] pci_bus 0000:00: root bus resource [mem 0x000c4000-0x000c7fff window]
-[    1.211879] pci_bus 0000:00: root bus resource [mem 0x000c8000-0x000cbfff window]
-[    1.211880] pci_bus 0000:00: root bus resource [mem 0x000cc000-0x000cffff window]
-[    1.211880] pci_bus 0000:00: root bus resource [mem 0x000d0000-0x000d3fff window]
-[    1.211881] pci_bus 0000:00: root bus resource [mem 0x000d4000-0x000d7fff window]
-[    1.211882] pci_bus 0000:00: root bus resource [mem 0x000d8000-0x000dbfff window]
-[    1.211883] pci_bus 0000:00: root bus resource [mem 0x000dc000-0x000dffff window]
-[    1.211883] pci_bus 0000:00: root bus resource [mem 0x000e0000-0x000e3fff window]
-[    1.211884] pci_bus 0000:00: root bus resource [mem 0x000e4000-0x000e7fff window]
-[    1.211885] pci_bus 0000:00: root bus resource [mem 0x000e8000-0x000ebfff window]
-[    1.211886] pci_bus 0000:00: root bus resource [mem 0x000ec000-0x000effff window]
-[    1.211886] pci_bus 0000:00: root bus resource [mem 0x000f0000-0x000fffff window]
-[    1.211887] pci_bus 0000:00: root bus resource [mem 0x80000000-0xfeafffff window]
-[    1.211888] pci_bus 0000:00: root bus resource [bus 00-ff]
-[    1.211894] pci 0000:00:00.0: [8086:1910] type 00 class 0x060000
-[    1.211981] pci 0000:00:01.0: [8086:1901] type 01 class 0x060400
-[    1.212013] pci 0000:00:01.0: PME# supported from D0 D3hot D3cold
-[    1.212043] pci 0000:00:01.0: System wakeup disabled by ACPI
-[    1.212070] pci 0000:00:01.1: [8086:1905] type 01 class 0x060400
-[    1.212100] pci 0000:00:01.1: PME# supported from D0 D3hot D3cold
-[    1.212134] pci 0000:00:01.1: System wakeup disabled by ACPI
-[    1.212160] pci 0000:00:01.2: [8086:1909] type 01 class 0x060400
-[    1.212190] pci 0000:00:01.2: PME# supported from D0 D3hot D3cold
-[    1.212224] pci 0000:00:01.2: System wakeup disabled by ACPI
-[    1.212334] pci 0000:00:14.0: [8086:a12f] type 00 class 0x0c0330
-[    1.212351] pci 0000:00:14.0: reg 0x10: [mem 0x82700000-0x8270ffff 64bit]
-[    1.212409] pci 0000:00:14.0: PME# supported from D3hot D3cold
-[    1.212439] pci 0000:00:14.0: System wakeup disabled by ACPI
-[    1.212580] pci 0000:00:15.0: [8086:a160] type 00 class 0x118000
-[    1.212764] pci 0000:00:15.0: reg 0x10: [mem 0x82728000-0x82728fff 64bit]
-[    1.213292] pci 0000:00:16.0: [8086:a13a] type 00 class 0x078000
-[    1.213307] pci 0000:00:16.0: reg 0x10: [mem 0x82729000-0x82729fff 64bit]
-[    1.213362] pci 0000:00:16.0: PME# supported from D3hot
-[    1.213506] pci 0000:00:19.0: [8086:a166] type 00 class 0x118000
-[    1.213614] pci 0000:00:19.0: reg 0x10: [mem 0x8272a000-0x8272afff 64bit]
-[    1.214168] pci 0000:00:1b.0: [8086:a167] type 01 class 0x060400
-[    1.214227] pci 0000:00:1b.0: PME# supported from D0 D3hot D3cold
-[    1.214266] pci 0000:00:1b.0: System wakeup disabled by ACPI
-[    1.214316] pci 0000:00:1c.0: [8086:a110] type 01 class 0x060400
-[    1.214373] pci 0000:00:1c.0: PME# supported from D0 D3hot D3cold
-[    1.214408] pci 0000:00:1c.0: System wakeup disabled by ACPI
-[    1.214558] pci 0000:00:1e.0: [8086:a127] type 00 class 0x118000
-[    1.214704] pci 0000:00:1e.0: reg 0x10: [mem 0x8272b000-0x8272bfff 64bit]
-[    1.215310] pci 0000:00:1e.1: [8086:a128] type 00 class 0x118000
-[    1.215444] pci 0000:00:1e.1: reg 0x10: [mem 0x8272c000-0x8272cfff 64bit]
-[    1.216094] pci 0000:00:1e.2: [8086:a129] type 00 class 0x118000
-[    1.216290] pci 0000:00:1e.2: reg 0x10: [mem 0x8272d000-0x8272dfff 64bit]
-[    1.216989] pci 0000:00:1e.3: [8086:a12a] type 00 class 0x118000
-[    1.217172] pci 0000:00:1e.3: reg 0x10: [mem 0x8272e000-0x8272efff 64bit]
-[    1.217825] pci 0000:00:1f.0: [8086:a151] type 00 class 0x060100
-[    1.217980] pci 0000:00:1f.2: [8086:a121] type 00 class 0x058000
-[    1.217988] pci 0000:00:1f.2: reg 0x10: [mem 0x82724000-0x82727fff]
-[    1.218086] pci 0000:00:1f.3: [8086:a170] type 00 class 0x040300
-[    1.218107] pci 0000:00:1f.3: reg 0x10: [mem 0x82720000-0x82723fff 64bit]
-[    1.218138] pci 0000:00:1f.3: reg 0x20: [mem 0x00000000-0x0000ffff 64bit]
-[    1.218182] pci 0000:00:1f.3: PME# supported from D3hot D3cold
-[    1.218219] pci 0000:00:1f.3: System wakeup disabled by ACPI
-[    1.218263] pci 0000:00:1f.4: [8086:a123] type 00 class 0x0c0500
-[    1.218309] pci 0000:00:1f.4: reg 0x10: [mem 0x8272f000-0x8272f0ff 64bit]
-[    1.218378] pci 0000:00:1f.4: reg 0x20: [io  0x5040-0x505f]
-[    1.218548] pci 0000:01:00.0: [1002:67ef] type 00 class 0x030000
-[    1.218561] pci 0000:01:00.0: reg 0x10: [mem 0xb0000000-0xbfffffff 64bit pref]
-[    1.218570] pci 0000:01:00.0: reg 0x18: [mem 0xc0000000-0xc01fffff 64bit pref]
-[    1.218576] pci 0000:01:00.0: reg 0x20: [io  0x4000-0x40ff]
-[    1.218581] pci 0000:01:00.0: reg 0x24: [mem 0x82600000-0x8263ffff]
-[    1.218587] pci 0000:01:00.0: reg 0x30: [mem 0x82640000-0x8265ffff pref]
-[    1.218623] pci 0000:01:00.0: supports D1 D2
-[    1.218647] pci 0000:01:00.0: System wakeup disabled by ACPI
-[    1.218678] pci 0000:01:00.1: [1002:aae0] type 00 class 0x040300
-[    1.218689] pci 0000:01:00.1: reg 0x10: [mem 0x82660000-0x82663fff 64bit]
-[    1.218741] pci 0000:01:00.1: supports D1 D2
-[    1.227773] pci 0000:00:01.0: PCI bridge to [bus 01]
-[    1.227775] pci 0000:00:01.0:   bridge window [io  0x4000-0x4fff]
-[    1.227776] pci 0000:00:01.0:   bridge window [mem 0x82600000-0x826fffff]
-[    1.227779] pci 0000:00:01.0:   bridge window [mem 0xb0000000-0xc01fffff 64bit pref]
-[    1.227827] pci 0000:04:00.0: [8086:1578] type 01 class 0x060400
-[    1.227898] pci 0000:04:00.0: supports D1 D2
-[    1.227899] pci 0000:04:00.0: PME# supported from D0 D1 D2 D3hot D3cold
-[    1.237778] pci 0000:00:01.1: PCI bridge to [bus 04-79]
-[    1.237780] pci 0000:00:01.1:   bridge window [io  0x6000-0x9fff]
-[    1.237782] pci 0000:00:01.1:   bridge window [mem 0x82800000-0x909fffff]
-[    1.237784] pci 0000:00:01.1:   bridge window [mem 0xc0200000-0xce1fffff 64bit pref]
-[    1.237868] pci 0000:05:00.0: [8086:15d3] type 01 class 0x060400
-[    1.237946] pci 0000:05:00.0: supports D1 D2
-[    1.237946] pci 0000:05:00.0: PME# supported from D0 D1 D2 D3hot D3cold
-[    1.238025] pci 0000:05:01.0: [8086:15d3] type 01 class 0x060400
-[    1.238101] pci 0000:05:01.0: supports D1 D2
-[    1.238102] pci 0000:05:01.0: PME# supported from D0 D1 D2 D3hot D3cold
-[    1.238159] pci 0000:05:02.0: [8086:15d3] type 01 class 0x060400
-[    1.238234] pci 0000:05:02.0: supports D1 D2
-[    1.238234] pci 0000:05:02.0: PME# supported from D0 D1 D2 D3hot D3cold
-[    1.238311] pci 0000:05:04.0: [8086:15d3] type 01 class 0x060400
-[    1.238386] pci 0000:05:04.0: supports D1 D2
-[    1.238387] pci 0000:05:04.0: PME# supported from D0 D1 D2 D3hot D3cold
-[    1.238457] pci 0000:04:00.0: PCI bridge to [bus 05-79]
-[    1.238461] pci 0000:04:00.0:   bridge window [io  0x0000-0x0fff]
-[    1.238463] pci 0000:04:00.0:   bridge window [mem 0x82800000-0x909fffff]
-[    1.238467] pci 0000:04:00.0:   bridge window [mem 0xc0200000-0xce1fffff 64bit pref]
-[    1.238519] pci 0000:06:00.0: [8086:15d2] type 00 class 0x088000
-[    1.238533] pci 0000:06:00.0: reg 0x10: [mem 0x82900000-0x8293ffff]
-[    1.238541] pci 0000:06:00.0: reg 0x14: [mem 0x82940000-0x82940fff]
-[    1.238646] pci 0000:06:00.0: supports D1 D2
-[    1.238646] pci 0000:06:00.0: PME# supported from D0 D1 D2 D3hot D3cold
-[    1.247790] pci 0000:05:00.0: PCI bridge to [bus 06]
-[    1.247794] pci 0000:05:00.0:   bridge window [io  0x0000-0x0fff]
-[    1.247797] pci 0000:05:00.0:   bridge window [mem 0x82900000-0x829fffff]
-[    1.247856] pci 0000:05:01.0: PCI bridge to [bus 08-40]
-[    1.247860] pci 0000:05:01.0:   bridge window [io  0x0000-0x0fff]
-[    1.247863] pci 0000:05:01.0:   bridge window [mem 0x82a00000-0x899fffff]
-[    1.247867] pci 0000:05:01.0:   bridge window [mem 0xc0200000-0xc71fffff 64bit pref]
-[    1.247918] pci 0000:07:00.0: [8086:15d4] type 00 class 0x0c0330
-[    1.247931] pci 0000:07:00.0: reg 0x10: [mem 0x00000000-0x0000ffff]
-[    1.248039] pci 0000:07:00.0: supports D1 D2
-[    1.248040] pci 0000:07:00.0: PME# supported from D0 D1 D2 D3hot D3cold
-[    1.248125] pci 0000:07:00.0: System wakeup disabled by ACPI
-[    1.257795] pci 0000:05:02.0: PCI bridge to [bus 07]
-[    1.257799] pci 0000:05:02.0:   bridge window [io  0x0000-0x0fff]
-[    1.257802] pci 0000:05:02.0:   bridge window [mem 0x82800000-0x828fffff]
-[    1.257862] pci 0000:05:04.0: PCI bridge to [bus 41-79]
-[    1.257866] pci 0000:05:04.0:   bridge window [io  0x0000-0x0fff]
-[    1.257868] pci 0000:05:04.0:   bridge window [mem 0x89a00000-0x909fffff]
-[    1.257872] pci 0000:05:04.0:   bridge window [mem 0xc7200000-0xce1fffff 64bit pref]
-[    1.257936] pci 0000:7a:00.0: [8086:1578] type 01 class 0x060400
-[    1.258006] pci 0000:7a:00.0: supports D1 D2
-[    1.258007] pci 0000:7a:00.0: PME# supported from D0 D1 D2 D3hot D3cold
-[    1.267799] pci 0000:00:01.2: PCI bridge to [bus 7a-ef]
-[    1.267801] pci 0000:00:01.2:   bridge window [io  0xa000-0xdfff]
-[    1.267803] pci 0000:00:01.2:   bridge window [mem 0x90a00000-0x9ebfffff]
-[    1.267806] pci 0000:00:01.2:   bridge window [mem 0xce200000-0xdc1fffff 64bit pref]
-[    1.267888] pci 0000:7b:00.0: [8086:15d3] type 01 class 0x060400
-[    1.267965] pci 0000:7b:00.0: supports D1 D2
-[    1.267966] pci 0000:7b:00.0: PME# supported from D0 D1 D2 D3hot D3cold
-[    1.268043] pci 0000:7b:01.0: [8086:15d3] type 01 class 0x060400
-[    1.268118] pci 0000:7b:01.0: supports D1 D2
-[    1.268119] pci 0000:7b:01.0: PME# supported from D0 D1 D2 D3hot D3cold
-[    1.268175] pci 0000:7b:02.0: [8086:15d3] type 01 class 0x060400
-[    1.268249] pci 0000:7b:02.0: supports D1 D2
-[    1.268250] pci 0000:7b:02.0: PME# supported from D0 D1 D2 D3hot D3cold
-[    1.268326] pci 0000:7b:04.0: [8086:15d3] type 01 class 0x060400
-[    1.268401] pci 0000:7b:04.0: supports D1 D2
-[    1.268402] pci 0000:7b:04.0: PME# supported from D0 D1 D2 D3hot D3cold
-[    1.268471] pci 0000:7a:00.0: PCI bridge to [bus 7b-ef]
-[    1.268475] pci 0000:7a:00.0:   bridge window [io  0x0000-0x0fff]
-[    1.268477] pci 0000:7a:00.0:   bridge window [mem 0x90a00000-0x9ebfffff]
-[    1.268481] pci 0000:7a:00.0:   bridge window [mem 0xce200000-0xdc1fffff 64bit pref]
-[    1.268533] pci 0000:7c:00.0: [8086:15d2] type 00 class 0x088000
-[    1.268546] pci 0000:7c:00.0: reg 0x10: [mem 0x90b00000-0x90b3ffff]
-[    1.268555] pci 0000:7c:00.0: reg 0x14: [mem 0x90b40000-0x90b40fff]
-[    1.268660] pci 0000:7c:00.0: supports D1 D2
-[    1.268660] pci 0000:7c:00.0: PME# supported from D0 D1 D2 D3hot D3cold
-[    1.277815] pci 0000:7b:00.0: PCI bridge to [bus 7c]
-[    1.277819] pci 0000:7b:00.0:   bridge window [io  0x0000-0x0fff]
-[    1.277822] pci 0000:7b:00.0:   bridge window [mem 0x90b00000-0x90bfffff]
-[    1.277881] pci 0000:7b:01.0: PCI bridge to [bus 7e-b6]
-[    1.277885] pci 0000:7b:01.0:   bridge window [io  0x0000-0x0fff]
-[    1.277888] pci 0000:7b:01.0:   bridge window [mem 0x90c00000-0x97bfffff]
-[    1.277892] pci 0000:7b:01.0:   bridge window [mem 0xce200000-0xd51fffff 64bit pref]
-[    1.277941] pci 0000:7d:00.0: [8086:15d4] type 00 class 0x0c0330
-[    1.277954] pci 0000:7d:00.0: reg 0x10: [mem 0x00000000-0x0000ffff]
-[    1.278061] pci 0000:7d:00.0: supports D1 D2
-[    1.278062] pci 0000:7d:00.0: PME# supported from D0 D1 D2 D3hot D3cold
-[    1.278145] pci 0000:7d:00.0: System wakeup disabled by ACPI
-[    1.287820] pci 0000:7b:02.0: PCI bridge to [bus 7d]
-[    1.287824] pci 0000:7b:02.0:   bridge window [io  0x0000-0x0fff]
-[    1.287826] pci 0000:7b:02.0:   bridge window [mem 0x90a00000-0x90afffff]
-[    1.287885] pci 0000:7b:04.0: PCI bridge to [bus b7-ef]
-[    1.287889] pci 0000:7b:04.0:   bridge window [io  0x0000-0x0fff]
-[    1.287891] pci 0000:7b:04.0:   bridge window [mem 0x97c00000-0x9ebfffff]
-[    1.287895] pci 0000:7b:04.0:   bridge window [mem 0xd5200000-0xdc1fffff 64bit pref]
-[    1.288123] pci 0000:02:00.0: [144d:a804] type 00 class 0x010802
-[    1.288139] pci 0000:02:00.0: reg 0x10: [mem 0x82500000-0x82503fff 64bit]
-[    1.288147] pci 0000:02:00.0: reg 0x18: [io  0x3000-0x30ff]
-[    1.297988] pci 0000:00:1b.0: PCI bridge to [bus 02]
-[    1.297990] pci 0000:00:1b.0:   bridge window [io  0x3000-0x3fff]
-[    1.297992] pci 0000:00:1b.0:   bridge window [mem 0x82500000-0x825fffff]
-[    1.298070] pci 0000:03:00.0: [14e4:43ba] type 00 class 0x028000
-[    1.298092] pci 0000:03:00.0: reg 0x10: [mem 0x82400000-0x82407fff 64bit]
-[    1.298107] pci 0000:03:00.0: reg 0x18: [mem 0x82000000-0x823fffff 64bit]
-[    1.298214] pci 0000:03:00.0: supports D1 D2
-[    1.298215] pci 0000:03:00.0: PME# supported from D0 D1 D2 D3hot D3cold
-[    1.298271] pci 0000:03:00.0: System wakeup disabled by ACPI
-[    1.307866] pci 0000:00:1c.0: PCI bridge to [bus 03]
-[    1.307870] pci 0000:00:1c.0:   bridge window [mem 0x82000000-0x824fffff]
-[    1.308761] ACPI: PCI Interrupt Link [LNKA] (IRQs 1 3 4 5 6 7 10 12 14 15) *0
-[    1.308820] ACPI: PCI Interrupt Link [LNKB] (IRQs 1 3 4 5 6 7 11 12 14 15) *0
-[    1.308878] ACPI: PCI Interrupt Link [LNKC] (IRQs 1 3 4 5 6 7 10 12 14 15) *0
-[    1.308936] ACPI: PCI Interrupt Link [LNKD] (IRQs 1 3 4 5 6 7 11 12 14 15) *0
-[    1.308993] ACPI: PCI Interrupt Link [LNKE] (IRQs 1 3 4 5 6 7 10 12 14 15) *0
-[    1.309050] ACPI: PCI Interrupt Link [LNKF] (IRQs 1 3 4 5 6 7 11 12 14 15) *0
-[    1.309106] ACPI: PCI Interrupt Link [LNKG] (IRQs 1 3 4 5 6 7 10 12 14 15) *0
-[    1.309162] ACPI: PCI Interrupt Link [LNKH] (IRQs 1 3 4 5 6 7 11 12 14 15) *0
-[    1.309319] ACPI: Enabled 4 GPEs in block 00 to 7F
-[    1.309378] ACPI : EC: event unblocked
-[    1.309388] ACPI: \_SB_.PCI0.LPCB.EC__: GPE=0x7, EC_CMD/EC_SC=0x66, EC_DATA=0x62
-[    1.309389] ACPI: \_SB_.PCI0.LPCB.EC__: Used as boot DSDT EC to handle transactions and events
-[    1.309530] pci 0000:01:00.0: vgaarb: VGA device added: decodes=io+mem,owns=none,locks=none
-[    1.309533] pci 0000:01:00.0: vgaarb: setting as boot device
-[    1.309534] pci 0000:01:00.0: vgaarb: bridge control possible
-[    1.309534] vgaarb: loaded
-[    1.309569] Registered efivars operations
-[    1.591096] PCI: Using ACPI for IRQ routing
-[    1.597830] PCI: pci_cache_line_size set to 64 bytes
-[    1.598407] e820: reserve RAM buffer [mem 0x00058000-0x0005ffff]
-[    1.598407] e820: reserve RAM buffer [mem 0x0009e000-0x0009ffff]
-[    1.598408] e820: reserve RAM buffer [mem 0x74035000-0x77ffffff]
-[    1.598408] e820: reserve RAM buffer [mem 0x74e18000-0x77ffffff]
-[    1.598409] e820: reserve RAM buffer [mem 0x7507e000-0x77ffffff]
-[    1.598410] e820: reserve RAM buffer [mem 0x7ac7f000-0x7bffffff]
-[    1.598410] e820: reserve RAM buffer [mem 0x7b000000-0x7bffffff]
-[    1.598411] e820: reserve RAM buffer [mem 0x47f000000-0x47fffffff]
-[    1.598467] NetLabel: Initializing
-[    1.598468] NetLabel:  domain hash size = 128
-[    1.598468] NetLabel:  protocols = UNLABELED CIPSOv4 CALIPSO
-[    1.598479] NetLabel:  unlabeled traffic allowed by default
-[    1.598555] hpet0: at MMIO 0xfed00000, IRQs 2, 8, 0, 0, 0, 0, 0, 0
-[    1.598558] hpet0: 8 comparators, 64-bit 24.000000 MHz counter
-[    1.600604] clocksource: Switched to clocksource hpet
-[    1.604657] VFS: Disk quotas dquot_6.6.0
-[    1.604671] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
-[    1.604717] pnp: PnP ACPI init
-[    1.605130] system 00:00: [io  0xffff] has been reserved
-[    1.605131] system 00:00: [io  0x1800-0x18fe] has been reserved
-[    1.605132] system 00:00: [io  0x0800-0x087f] has been reserved
-[    1.605134] system 00:00: Plug and Play ACPI device, IDs PNP0c02 (active)
-[    1.605147] pnp 00:01: Plug and Play ACPI device, IDs PNP0b00 (active)
-[    1.605182] pnp 00:02: Plug and Play ACPI device, IDs APP000b (active)
-[    1.605286] system 00:03: [mem 0xfed10000-0xfed17fff] has been reserved
-[    1.605287] system 00:03: [mem 0xfed18000-0xfed18fff] has been reserved
-[    1.605287] system 00:03: [mem 0xfed19000-0xfed19fff] has been reserved
-[    1.605288] system 00:03: [mem 0xe0000000-0xefffffff] could not be reserved
-[    1.605289] system 00:03: [mem 0xfd000000-0xfe7fffff] could not be reserved
-[    1.605290] system 00:03: [mem 0xfed20000-0xfed3ffff] has been reserved
-[    1.605291] system 00:03: [mem 0xfed90000-0xfed93fff] could not be reserved
-[    1.605292] system 00:03: [mem 0xfed45000-0xfed8ffff] has been reserved
-[    1.605293] system 00:03: [mem 0xff000000-0xffffffff] could not be reserved
-[    1.605293] system 00:03: [mem 0xfee00000-0xfeefffff] has been reserved
-[    1.605295] system 00:03: Plug and Play ACPI device, IDs PNP0c02 (active)
-[    1.605326] system 00:04: [mem 0x20000000-0x201fffff] could not be reserved
-[    1.605326] system 00:04: [mem 0x40000000-0x401fffff] could not be reserved
-[    1.605328] system 00:04: Plug and Play ACPI device, IDs PNP0c01 (active)
-[    1.605415] pnp: PnP ACPI: found 5 devices
-[    1.612205] clocksource: acpi_pm: mask: 0xffffff max_cycles: 0xffffff, max_idle_ns: 2085701024 ns
-[    1.612222] pci 0000:05:01.0: bridge window [io  0x1000-0x0fff] to [bus 08-40] add_size 1000
-[    1.612227] pci 0000:05:02.0: bridge window [io  0x1000-0x0fff] to [bus 07] add_size 1000
-[    1.612229] pci 0000:05:02.0: bridge window [mem 0x00100000-0x000fffff 64bit pref] to [bus 07] add_size 200000 add_align 100000
-[    1.612234] pci 0000:05:04.0: bridge window [io  0x1000-0x0fff] to [bus 41-79] add_size 1000
-[    1.612239] pci 0000:05:01.0: res[13]=[io  0x1000-0x0fff] res_to_dev_res add_size 1000 min_align 1000
-[    1.612240] pci 0000:05:02.0: res[13]=[io  0x1000-0x0fff] res_to_dev_res add_size 1000 min_align 1000
-[    1.612241] pci 0000:05:04.0: res[13]=[io  0x1000-0x0fff] res_to_dev_res add_size 1000 min_align 1000
-[    1.612242] pci 0000:04:00.0: bridge window [io  0x1000-0x0fff] to [bus 05-79] add_size 3000
-[    1.612254] pci 0000:7b:01.0: bridge window [io  0x1000-0x0fff] to [bus 7e-b6] add_size 1000
-[    1.612260] pci 0000:7b:02.0: bridge window [io  0x1000-0x0fff] to [bus 7d] add_size 1000
-[    1.612261] pci 0000:7b:02.0: bridge window [mem 0x00100000-0x000fffff 64bit pref] to [bus 7d] add_size 200000 add_align 100000
-[    1.612266] pci 0000:7b:04.0: bridge window [io  0x1000-0x0fff] to [bus b7-ef] add_size 1000
-[    1.612271] pci 0000:7b:01.0: res[13]=[io  0x1000-0x0fff] res_to_dev_res add_size 1000 min_align 1000
-[    1.612272] pci 0000:7b:02.0: res[13]=[io  0x1000-0x0fff] res_to_dev_res add_size 1000 min_align 1000
-[    1.612272] pci 0000:7b:04.0: res[13]=[io  0x1000-0x0fff] res_to_dev_res add_size 1000 min_align 1000
-[    1.612273] pci 0000:7a:00.0: bridge window [io  0x1000-0x0fff] to [bus 7b-ef] add_size 3000
-[    1.612299] pci 0000:00:1f.3: BAR 4: assigned [mem 0x80000000-0x8000ffff 64bit]
-[    1.612310] pci 0000:00:01.0: PCI bridge to [bus 01]
-[    1.612311] pci 0000:00:01.0:   bridge window [io  0x4000-0x4fff]
-[    1.612313] pci 0000:00:01.0:   bridge window [mem 0x82600000-0x826fffff]
-[    1.612314] pci 0000:00:01.0:   bridge window [mem 0xb0000000-0xc01fffff 64bit pref]
-[    1.612317] pci 0000:04:00.0: res[13]=[io  0x1000-0x0fff] res_to_dev_res add_size 3000 min_align 1000
-[    1.612318] pci 0000:04:00.0: res[13]=[io  0x1000-0x3fff] res_to_dev_res add_size 3000 min_align 1000
-[    1.612318] pci 0000:04:00.0: BAR 13: assigned [io  0x6000-0x8fff]
-[    1.612320] pci 0000:05:02.0: res[15]=[mem 0x00100000-0x000fffff 64bit pref] res_to_dev_res add_size 200000 min_align 100000
-[    1.612321] pci 0000:05:02.0: res[15]=[mem 0x00100000-0x002fffff 64bit pref] res_to_dev_res add_size 200000 min_align 100000
-[    1.612322] pci 0000:05:01.0: res[13]=[io  0x1000-0x0fff] res_to_dev_res add_size 1000 min_align 1000
-[    1.612323] pci 0000:05:01.0: res[13]=[io  0x1000-0x1fff] res_to_dev_res add_size 1000 min_align 1000
-[    1.612323] pci 0000:05:02.0: res[13]=[io  0x1000-0x0fff] res_to_dev_res add_size 1000 min_align 1000
-[    1.612324] pci 0000:05:02.0: res[13]=[io  0x1000-0x1fff] res_to_dev_res add_size 1000 min_align 1000
-[    1.612325] pci 0000:05:04.0: res[13]=[io  0x1000-0x0fff] res_to_dev_res add_size 1000 min_align 1000
-[    1.612325] pci 0000:05:04.0: res[13]=[io  0x1000-0x1fff] res_to_dev_res add_size 1000 min_align 1000
-[    1.612328] pci 0000:05:02.0: BAR 15: no space for [mem size 0x00200000 64bit pref]
-[    1.612328] pci 0000:05:02.0: BAR 15: failed to assign [mem size 0x00200000 64bit pref]
-[    1.612329] pci 0000:05:01.0: BAR 13: assigned [io  0x6000-0x6fff]
-[    1.612330] pci 0000:05:02.0: BAR 13: assigned [io  0x7000-0x7fff]
-[    1.612331] pci 0000:05:04.0: BAR 13: assigned [io  0x8000-0x8fff]
-[    1.612333] pci 0000:05:02.0: BAR 15: no space for [mem size 0x00200000 64bit pref]
-[    1.612334] pci 0000:05:02.0: BAR 15: failed to assign [mem size 0x00200000 64bit pref]
-[    1.612334] pci 0000:05:00.0: PCI bridge to [bus 06]
-[    1.612337] pci 0000:05:00.0:   bridge window [mem 0x82900000-0x829fffff]
-[    1.612343] pci 0000:05:01.0: PCI bridge to [bus 08-40]
-[    1.612344] pci 0000:05:01.0:   bridge window [io  0x6000-0x6fff]
-[    1.612347] pci 0000:05:01.0:   bridge window [mem 0x82a00000-0x899fffff]
-[    1.612349] pci 0000:05:01.0:   bridge window [mem 0xc0200000-0xc71fffff 64bit pref]
-[    1.612353] pci 0000:07:00.0: BAR 0: assigned [mem 0x82800000-0x8280ffff]
-[    1.612356] pci 0000:05:02.0: PCI bridge to [bus 07]
-[    1.612358] pci 0000:05:02.0:   bridge window [io  0x7000-0x7fff]
-[    1.612360] pci 0000:05:02.0:   bridge window [mem 0x82800000-0x828fffff]
-[    1.612365] pci 0000:05:04.0: PCI bridge to [bus 41-79]
-[    1.612367] pci 0000:05:04.0:   bridge window [io  0x8000-0x8fff]
-[    1.612370] pci 0000:05:04.0:   bridge window [mem 0x89a00000-0x909fffff]
-[    1.612372] pci 0000:05:04.0:   bridge window [mem 0xc7200000-0xce1fffff 64bit pref]
-[    1.612375] pci 0000:04:00.0: PCI bridge to [bus 05-79]
-[    1.612376] pci 0000:04:00.0:   bridge window [io  0x6000-0x8fff]
-[    1.612379] pci 0000:04:00.0:   bridge window [mem 0x82800000-0x909fffff]
-[    1.612381] pci 0000:04:00.0:   bridge window [mem 0xc0200000-0xce1fffff 64bit pref]
-[    1.612385] pci 0000:00:01.1: PCI bridge to [bus 04-79]
-[    1.612386] pci 0000:00:01.1:   bridge window [io  0x6000-0x9fff]
-[    1.612387] pci 0000:00:01.1:   bridge window [mem 0x82800000-0x909fffff]
-[    1.612389] pci 0000:00:01.1:   bridge window [mem 0xc0200000-0xce1fffff 64bit pref]
-[    1.612391] pci 0000:7a:00.0: res[13]=[io  0x1000-0x0fff] res_to_dev_res add_size 3000 min_align 1000
-[    1.612392] pci 0000:7a:00.0: res[13]=[io  0x1000-0x3fff] res_to_dev_res add_size 3000 min_align 1000
-[    1.612393] pci 0000:7a:00.0: BAR 13: assigned [io  0xa000-0xcfff]
-[    1.612394] pci 0000:7b:02.0: res[15]=[mem 0x00100000-0x000fffff 64bit pref] res_to_dev_res add_size 200000 min_align 100000
-[    1.612395] pci 0000:7b:02.0: res[15]=[mem 0x00100000-0x002fffff 64bit pref] res_to_dev_res add_size 200000 min_align 100000
-[    1.612395] pci 0000:7b:01.0: res[13]=[io  0x1000-0x0fff] res_to_dev_res add_size 1000 min_align 1000
-[    1.612396] pci 0000:7b:01.0: res[13]=[io  0x1000-0x1fff] res_to_dev_res add_size 1000 min_align 1000
-[    1.612397] pci 0000:7b:02.0: res[13]=[io  0x1000-0x0fff] res_to_dev_res add_size 1000 min_align 1000
-[    1.612398] pci 0000:7b:02.0: res[13]=[io  0x1000-0x1fff] res_to_dev_res add_size 1000 min_align 1000
-[    1.612398] pci 0000:7b:04.0: res[13]=[io  0x1000-0x0fff] res_to_dev_res add_size 1000 min_align 1000
-[    1.612399] pci 0000:7b:04.0: res[13]=[io  0x1000-0x1fff] res_to_dev_res add_size 1000 min_align 1000
-[    1.612401] pci 0000:7b:02.0: BAR 15: no space for [mem size 0x00200000 64bit pref]
-[    1.612401] pci 0000:7b:02.0: BAR 15: failed to assign [mem size 0x00200000 64bit pref]
-[    1.612402] pci 0000:7b:01.0: BAR 13: assigned [io  0xa000-0xafff]
-[    1.612403] pci 0000:7b:02.0: BAR 13: assigned [io  0xb000-0xbfff]
-[    1.612403] pci 0000:7b:04.0: BAR 13: assigned [io  0xc000-0xcfff]
-[    1.612405] pci 0000:7b:02.0: BAR 15: no space for [mem size 0x00200000 64bit pref]
-[    1.612406] pci 0000:7b:02.0: BAR 15: failed to assign [mem size 0x00200000 64bit pref]
-[    1.612406] pci 0000:7b:00.0: PCI bridge to [bus 7c]
-[    1.612409] pci 0000:7b:00.0:   bridge window [mem 0x90b00000-0x90bfffff]
-[    1.612414] pci 0000:7b:01.0: PCI bridge to [bus 7e-b6]
-[    1.612416] pci 0000:7b:01.0:   bridge window [io  0xa000-0xafff]
-[    1.612419] pci 0000:7b:01.0:   bridge window [mem 0x90c00000-0x97bfffff]
-[    1.612421] pci 0000:7b:01.0:   bridge window [mem 0xce200000-0xd51fffff 64bit pref]
-[    1.612425] pci 0000:7d:00.0: BAR 0: assigned [mem 0x90a00000-0x90a0ffff]
-[    1.612428] pci 0000:7b:02.0: PCI bridge to [bus 7d]
-[    1.612429] pci 0000:7b:02.0:   bridge window [io  0xb000-0xbfff]
-[    1.612432] pci 0000:7b:02.0:   bridge window [mem 0x90a00000-0x90afffff]
-[    1.612437] pci 0000:7b:04.0: PCI bridge to [bus b7-ef]
-[    1.612438] pci 0000:7b:04.0:   bridge window [io  0xc000-0xcfff]
-[    1.612441] pci 0000:7b:04.0:   bridge window [mem 0x97c00000-0x9ebfffff]
-[    1.612443] pci 0000:7b:04.0:   bridge window [mem 0xd5200000-0xdc1fffff 64bit pref]
-[    1.612446] pci 0000:7a:00.0: PCI bridge to [bus 7b-ef]
-[    1.612448] pci 0000:7a:00.0:   bridge window [io  0xa000-0xcfff]
-[    1.612450] pci 0000:7a:00.0:   bridge window [mem 0x90a00000-0x9ebfffff]
-[    1.612452] pci 0000:7a:00.0:   bridge window [mem 0xce200000-0xdc1fffff 64bit pref]
-[    1.612456] pci 0000:00:01.2: PCI bridge to [bus 7a-ef]
-[    1.612457] pci 0000:00:01.2:   bridge window [io  0xa000-0xdfff]
-[    1.612458] pci 0000:00:01.2:   bridge window [mem 0x90a00000-0x9ebfffff]
-[    1.612460] pci 0000:00:01.2:   bridge window [mem 0xce200000-0xdc1fffff 64bit pref]
-[    1.612462] pci 0000:00:1b.0: PCI bridge to [bus 02]
-[    1.612465] pci 0000:00:1b.0:   bridge window [io  0x3000-0x3fff]
-[    1.612467] pci 0000:00:1b.0:   bridge window [mem 0x82500000-0x825fffff]
-[    1.612472] pci 0000:00:1c.0: PCI bridge to [bus 03]
-[    1.612475] pci 0000:00:1c.0:   bridge window [mem 0x82000000-0x824fffff]
-[    1.612480] pci_bus 0000:00: resource 4 [io  0x0000-0x0cf7 window]
-[    1.612481] pci_bus 0000:00: resource 5 [io  0x0d00-0xffff window]
-[    1.612482] pci_bus 0000:00: resource 6 [mem 0x000a0000-0x000bffff window]
-[    1.612483] pci_bus 0000:00: resource 7 [mem 0x000c0000-0x000c3fff window]
-[    1.612483] pci_bus 0000:00: resource 8 [mem 0x000c4000-0x000c7fff window]
-[    1.612484] pci_bus 0000:00: resource 9 [mem 0x000c8000-0x000cbfff window]
-[    1.612485] pci_bus 0000:00: resource 10 [mem 0x000cc000-0x000cffff window]
-[    1.612485] pci_bus 0000:00: resource 11 [mem 0x000d0000-0x000d3fff window]
-[    1.612486] pci_bus 0000:00: resource 12 [mem 0x000d4000-0x000d7fff window]
-[    1.612487] pci_bus 0000:00: resource 13 [mem 0x000d8000-0x000dbfff window]
-[    1.612487] pci_bus 0000:00: resource 14 [mem 0x000dc000-0x000dffff window]
-[    1.612488] pci_bus 0000:00: resource 15 [mem 0x000e0000-0x000e3fff window]
-[    1.612488] pci_bus 0000:00: resource 16 [mem 0x000e4000-0x000e7fff window]
-[    1.612489] pci_bus 0000:00: resource 17 [mem 0x000e8000-0x000ebfff window]
-[    1.612490] pci_bus 0000:00: resource 18 [mem 0x000ec000-0x000effff window]
-[    1.612490] pci_bus 0000:00: resource 19 [mem 0x000f0000-0x000fffff window]
-[    1.612491] pci_bus 0000:00: resource 20 [mem 0x80000000-0xfeafffff window]
-[    1.612492] pci_bus 0000:01: resource 0 [io  0x4000-0x4fff]
-[    1.612492] pci_bus 0000:01: resource 1 [mem 0x82600000-0x826fffff]
-[    1.612493] pci_bus 0000:01: resource 2 [mem 0xb0000000-0xc01fffff 64bit pref]
-[    1.612494] pci_bus 0000:04: resource 0 [io  0x6000-0x9fff]
-[    1.612494] pci_bus 0000:04: resource 1 [mem 0x82800000-0x909fffff]
-[    1.612495] pci_bus 0000:04: resource 2 [mem 0xc0200000-0xce1fffff 64bit pref]
-[    1.612496] pci_bus 0000:05: resource 0 [io  0x6000-0x8fff]
-[    1.612496] pci_bus 0000:05: resource 1 [mem 0x82800000-0x909fffff]
-[    1.612497] pci_bus 0000:05: resource 2 [mem 0xc0200000-0xce1fffff 64bit pref]
-[    1.612497] pci_bus 0000:06: resource 1 [mem 0x82900000-0x829fffff]
-[    1.612498] pci_bus 0000:08: resource 0 [io  0x6000-0x6fff]
-[    1.612499] pci_bus 0000:08: resource 1 [mem 0x82a00000-0x899fffff]
-[    1.612499] pci_bus 0000:08: resource 2 [mem 0xc0200000-0xc71fffff 64bit pref]
-[    1.612500] pci_bus 0000:07: resource 0 [io  0x7000-0x7fff]
-[    1.612501] pci_bus 0000:07: resource 1 [mem 0x82800000-0x828fffff]
-[    1.612501] pci_bus 0000:41: resource 0 [io  0x8000-0x8fff]
-[    1.612502] pci_bus 0000:41: resource 1 [mem 0x89a00000-0x909fffff]
-[    1.612503] pci_bus 0000:41: resource 2 [mem 0xc7200000-0xce1fffff 64bit pref]
-[    1.612503] pci_bus 0000:7a: resource 0 [io  0xa000-0xdfff]
-[    1.612504] pci_bus 0000:7a: resource 1 [mem 0x90a00000-0x9ebfffff]
-[    1.612504] pci_bus 0000:7a: resource 2 [mem 0xce200000-0xdc1fffff 64bit pref]
-[    1.612505] pci_bus 0000:7b: resource 0 [io  0xa000-0xcfff]
-[    1.612506] pci_bus 0000:7b: resource 1 [mem 0x90a00000-0x9ebfffff]
-[    1.612506] pci_bus 0000:7b: resource 2 [mem 0xce200000-0xdc1fffff 64bit pref]
-[    1.612507] pci_bus 0000:7c: resource 1 [mem 0x90b00000-0x90bfffff]
-[    1.612508] pci_bus 0000:7e: resource 0 [io  0xa000-0xafff]
-[    1.612508] pci_bus 0000:7e: resource 1 [mem 0x90c00000-0x97bfffff]
-[    1.612509] pci_bus 0000:7e: resource 2 [mem 0xce200000-0xd51fffff 64bit pref]
-[    1.612509] pci_bus 0000:7d: resource 0 [io  0xb000-0xbfff]
-[    1.612510] pci_bus 0000:7d: resource 1 [mem 0x90a00000-0x90afffff]
-[    1.612511] pci_bus 0000:b7: resource 0 [io  0xc000-0xcfff]
-[    1.612511] pci_bus 0000:b7: resource 1 [mem 0x97c00000-0x9ebfffff]
-[    1.612512] pci_bus 0000:b7: resource 2 [mem 0xd5200000-0xdc1fffff 64bit pref]
-[    1.612513] pci_bus 0000:02: resource 0 [io  0x3000-0x3fff]
-[    1.612513] pci_bus 0000:02: resource 1 [mem 0x82500000-0x825fffff]
-[    1.612514] pci_bus 0000:03: resource 1 [mem 0x82000000-0x824fffff]
-[    1.612621] NET: Registered protocol family 2
-[    1.612750] TCP established hash table entries: 131072 (order: 8, 1048576 bytes)
-[    1.612879] TCP bind hash table entries: 65536 (order: 8, 1048576 bytes)
-[    1.612965] TCP: Hash tables configured (established 131072 bind 65536)
-[    1.612981] UDP hash table entries: 8192 (order: 6, 262144 bytes)
-[    1.613010] UDP-Lite hash table entries: 8192 (order: 6, 262144 bytes)
-[    1.613052] NET: Registered protocol family 1
-[    1.613465] pci 0000:07:00.0: enabling device (0000 -> 0002)
-[    1.613646] pci 0000:7d:00.0: enabling device (0000 -> 0002)
-[    1.613894] PCI: CLS 256 bytes, default 64
-[    1.613920] Unpacking initramfs...
-[    1.678077] Freeing initrd memory: 5504K
-[    1.678094] DMAR: ACPI device "device:91" under DMAR at fed91000 as 00:15.0
-[    1.678096] DMAR: ACPI device "device:92" under DMAR at fed91000 as 00:1e.2
-[    1.678097] DMAR: ACPI device "device:93" under DMAR at fed91000 as 00:1e.3
-[    1.678099] DMAR: Failed to find handle for ACPI object \_SB.PCI0.UA00
-[    1.678104] DMAR: Failed to find handle for ACPI object \_SB.PCI0.UA01
-[    1.678107] DMAR: Failed to find handle for ACPI object \_SB.PCI0.UA02
-[    1.678121] PCI-DMA: Using software bounce buffering for IO (SWIOTLB)
-[    1.678122] software IO TLB [mem 0x6c82a000-0x7082a000] (64MB) mapped at [ffff88006c82a000-ffff880070829fff]
-[    1.678319] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x255cb6cc5db, max_idle_ns: 440795203504 ns
-[    1.678486] Scanning for low memory corruption every 60 seconds
-[    1.678968] Initialise system trusted keyrings
-[    1.679075] workingset: timestamp_bits=40 max_order=22 bucket_order=0
-[    1.679967] zbud: loaded
-[    1.680749] Key type asymmetric registered
-[    1.680776] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 249)
-[    1.680813] io scheduler noop registered
-[    1.680813] io scheduler deadline registered
-[    1.680818] io scheduler cfq registered (default)
-[    1.682333] pciehp 0000:05:01.0:pcie204: Slot #1 AttnBtn- PwrCtrl- MRL- AttnInd- PwrInd- HotPlug+ Surprise+ Interlock- NoCompl+ LLActRep+
-[    1.682372] pciehp 0000:05:02.0:pcie204: Slot #0 AttnBtn- PwrCtrl- MRL- AttnInd- PwrInd- HotPlug+ Surprise+ Interlock- NoCompl+ LLActRep+
-[    1.682400] pciehp 0000:05:04.0:pcie204: Slot #4 AttnBtn- PwrCtrl- MRL- AttnInd- PwrInd- HotPlug+ Surprise+ Interlock- NoCompl+ LLActRep+
-[    1.682429] pciehp 0000:7b:01.0:pcie204: Slot #1 AttnBtn- PwrCtrl- MRL- AttnInd- PwrInd- HotPlug+ Surprise+ Interlock- NoCompl+ LLActRep+
-[    1.682457] pciehp 0000:7b:02.0:pcie204: Slot #0 AttnBtn- PwrCtrl- MRL- AttnInd- PwrInd- HotPlug+ Surprise+ Interlock- NoCompl+ LLActRep+
-[    1.682486] pciehp 0000:7b:04.0:pcie204: Slot #4 AttnBtn- PwrCtrl- MRL- AttnInd- PwrInd- HotPlug+ Surprise+ Interlock- NoCompl+ LLActRep+
-[    1.682519] efifb: probing for efifb
-[    1.682545] efifb: framebuffer at 0xb0300000, using 29440k, total 29440k
-[    1.682545] efifb: mode is 3360x2100x32, linelength=14336, pages=1
-[    1.682546] efifb: scrolling: redraw
-[    1.682546] efifb: Truecolor: size=8:8:8:8, shift=24:16:8:0
-[    1.692394] Console: switching to colour frame buffer device 420x131
-[    1.702113] fb0: EFI VGA frame buffer device
-[    1.702118] intel_idle: MWAIT substates: 0x11142120
-[    1.702119] intel_idle: v0.4.1 model 0x5E
-[    1.702121] intel_idle: state C8-SKL is disabled
-[    1.702122] intel_idle: state C9-SKL is disabled
-[    1.702480] intel_idle: lapic_timer_reliable_states 0xffffffff
-[    1.702910] GHES: HEST is not enabled!
-[    1.702967] Serial: 8250/16550 driver, 4 ports, IRQ sharing enabled
-[    1.703304] Linux agpgart interface v0.103
-[    1.703817] rtc_cmos 00:01: RTC can wake from S4
-[    1.704273] rtc_cmos 00:01: rtc core: registered rtc_cmos as rtc0
-[    1.704354] rtc_cmos 00:01: alarms up to one month, y3k, 242 bytes nvram, hpet irqs
-[    1.704358] intel_pstate: Intel P-state driver initializing
-[    1.705194] intel_pstate: HWP enabled
-[    1.705602] ledtrig-cpu: registered to indicate activity on CPUs
-[    1.705815] NET: Registered protocol family 10
-[    1.709450] Segment Routing with IPv6
-[    1.709461] NET: Registered protocol family 17
-[    1.710858] microcode: sig=0x506e3, pf=0x20, revision=0xae
-[    1.711208] microcode: Microcode Update Driver: v2.2.
-[    1.711602] registered taskstats version 1
-[    1.711607] Loading compiled-in X.509 certificates
-[    1.711618] zswap: loaded using pool lzo/zbud
-[    1.712698]   Magic number: 13:457:246
-[    1.712727] acpi device:89: hash matches
-[    1.712731] acpi device:5c: hash matches
-[    1.712744] memory memory120: hash matches
-[    1.712967] rtc_cmos 00:01: setting system clock to 2017-04-29 20:14:31 UTC (1493496871)
-[    1.713005] PM: Checking hibernation image partition UUID=2ee83f71-45e2-4469-a84c-78942ba69036
-[    1.713006] PM: Hibernation image not present or could not be loaded.
-[    1.713738] Freeing unused kernel memory: 1292K
-[    1.713738] Write protecting the kernel read-only data: 10240k
-[    1.714149] Freeing unused kernel memory: 1812K
-[    1.714309] Freeing unused kernel memory: 64K
-[    2.263330] random: systemd-tmpfile: uninitialized urandom read (16 bytes read)
-[    2.264677] random: systemd-udevd: uninitialized urandom read (16 bytes read)
-[    2.264718] random: systemd-udevd: uninitialized urandom read (16 bytes read)
-[    2.265215] random: udevadm: uninitialized urandom read (16 bytes read)
-[    2.265226] random: udevadm: uninitialized urandom read (16 bytes read)
-[    2.266661] random: systemd-udevd: uninitialized urandom read (16 bytes read)
-[    2.266671] random: systemd-udevd: uninitialized urandom read (16 bytes read)
-[    2.266674] random: systemd-udevd: uninitialized urandom read (16 bytes read)
-[    2.266850] random: systemd-udevd: uninitialized urandom read (16 bytes read)
-[    2.266859] random: systemd-udevd: uninitialized urandom read (16 bytes read)
-[    2.308190] ACPI: bus type USB registered
-[    2.308208] usbcore: registered new interface driver usbfs
-[    2.308214] usbcore: registered new interface driver hub
-[    2.308253] usbcore: registered new device driver usb
-[    2.309414] xhci_hcd 0000:00:14.0: xHCI Host Controller
-[    2.309419] xhci_hcd 0000:00:14.0: new USB bus registered, assigned bus number 1
-[    2.310570] xhci_hcd 0000:00:14.0: hcc params 0x200077c1 hci version 0x100 quirks 0x00109810
-[    2.310574] xhci_hcd 0000:00:14.0: cache line size of 256 is not supported
-[    2.310895] hub 1-0:1.0: USB hub found
-[    2.310926] hub 1-0:1.0: 16 ports detected
-[    2.311474] nvme nvme0: pci function 0000:02:00.0
-[    2.311641] xhci_hcd 0000:00:14.0: xHCI Host Controller
-[    2.311645] xhci_hcd 0000:00:14.0: new USB bus registered, assigned bus number 2
-[    2.311858] hub 2-0:1.0: USB hub found
-[    2.311889] hub 2-0:1.0: 8 ports detected
-[    2.312340] xhci_hcd 0000:07:00.0: xHCI Host Controller
-[    2.312347] xhci_hcd 0000:07:00.0: new USB bus registered, assigned bus number 3
-[    2.313567] xhci_hcd 0000:07:00.0: hcc params 0x200077c1 hci version 0x110 quirks 0x00009810
-[    2.313818] hub 3-0:1.0: USB hub found
-[    2.313838] hub 3-0:1.0: 2 ports detected
-[    2.313951] xhci_hcd 0000:07:00.0: xHCI Host Controller
-[    2.313953] xhci_hcd 0000:07:00.0: new USB bus registered, assigned bus number 4
-[    2.314260] hub 4-0:1.0: USB hub found
-[    2.314276] hub 4-0:1.0: 2 ports detected
-[    2.314579] xhci_hcd 0000:7d:00.0: xHCI Host Controller
-[    2.314582] xhci_hcd 0000:7d:00.0: new USB bus registered, assigned bus number 5
-[    2.315832] xhci_hcd 0000:7d:00.0: hcc params 0x200077c1 hci version 0x110 quirks 0x00009810
-[    2.316242] hub 5-0:1.0: USB hub found
-[    2.316256] hub 5-0:1.0: 2 ports detected
-[    2.316336] xhci_hcd 0000:7d:00.0: xHCI Host Controller
-[    2.316338] xhci_hcd 0000:7d:00.0: new USB bus registered, assigned bus number 6
-[    2.316630] hub 6-0:1.0: USB hub found
-[    2.316644] hub 6-0:1.0: 2 ports detected
-[    2.540853]  nvme0n1: p1 p2 p3 p4 p5 p6 p7
-[    2.630796] usb 1-3: new high-speed USB device number 2 using xhci_hcd
-[    2.634581] usb 4-1: new SuperSpeed USB device number 2 using xhci_hcd
-[    2.647745] PM: Starting manual resume from disk
-[    2.647750] PM: Hibernation image partition 259:5 present
-[    2.647751] PM: Looking for hibernation image.
-[    2.649738] PM: Image not found (code -22)
-[    2.649740] PM: Hibernation image not present or could not be loaded.
-[    2.655562] hub 4-1:1.0: USB hub found
-[    2.655709] hub 4-1:1.0: 4 ports detected
-[    2.694598] EXT4-fs (nvme0n1p4): mounted filesystem with ordered data mode. Opts: (null)
-[    2.697483] clocksource: Switched to clocksource tsc
-[    2.726370] random: fast init done
-[    2.747228] ip_tables: (C) 2000-2006 Netfilter Core Team
-[    2.750666] systemd[1]: systemd 232 running in system mode. (+PAM -AUDIT -SELINUX -IMA -APPARMOR +SMACK -SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD +IDN)
-[    2.750875] systemd[1]: Detected architecture x86-64.
-[    2.752619] systemd[1]: Set hostname to <guti-mac>.
-[    2.798957] systemd[1]: Created slice User and Session Slice.
-[    2.799113] systemd[1]: Set up automount Arbitrary Executable File Formats File System Automount Point.
-[    2.799125] systemd[1]: Reached target Remote File Systems.
-[    2.799149] systemd[1]: Listening on udev Control Socket.
-[    2.799167] systemd[1]: Listening on Device-mapper event daemon FIFOs.
-[    2.799193] systemd[1]: Listening on Journal Socket.
-[    2.799215] systemd[1]: Listening on /dev/initctl Compatibility Named Pipe.
-[    2.807439] EXT4-fs (nvme0n1p4): re-mounted. Opts: data=ordered
-[    2.812908] SCSI subsystem initialized
-[    2.845427] nf_conntrack version 0.5.0 (65536 buckets, 262144 max)
-[    2.851881] ip6_tables: (C) 2000-2006 Netfilter Core Team
-[    2.864165] ACPI: AC Adapter [ADP1] (on-line)
-[    2.865236] [Firmware Bug]: ACPI(GFX0) defines _DOD but not _DOS
-[    2.865251] ACPI: Video Device [GFX0] (multi-head: yes  rom: no  post: no)
-[    2.866909] input: Lid Switch as /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0C0D:00/input/input0
-[    2.866914] ACPI: Lid Switch [LID0]
-[    2.866957] acpi device:02: registered as cooling_device8
-[    2.866993] input: Video Bus as /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:01/LNXVIDEO:00/input/input1
-[    2.867218] input: Power Button as /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0C0C:00/input/input2
-[    2.867220] ACPI: Power Button [PWRB]
-[    2.867260] input: Sleep Button as /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0C0E:00/input/input3
-[    2.867262] ACPI: Sleep Button [SLPB]
-[    2.867305] input: Power Button as /devices/LNXSYSTM:00/LNXPWRBN:00/input/input4
-[    2.867307] ACPI: Power Button [PWRF]
-[    2.867345] FUJITSU Extended Socket Network Device Driver - version 1.2 - Copyright (c) 2015 FUJITSU LIMITED
-[    2.875598] apple_gmux: Found gmux version 4.0.29 [indexed]
-[    2.875606] apple_gmux: locked IO for PCI:0000:01:00.0
-[    2.877285] usb 1-11: new high-speed USB device number 3 using xhci_hcd
-[    2.879323] systemd-journald[200]: Received request to flush runtime journal from PID 1
-[    3.010437] hub 1-11:1.0: USB hub found
-[    3.010599] hub 1-11:1.0: 4 ports detected
-[    3.017558] ACPI: SBS HC: EC = 0xffff88046bdb4900, offset = 0x20, query_bit = 0x10
-[    3.018037] input: PC Speaker as /devices/platform/pcspkr/input/input5
-[    3.018130] shpchp: Standard Hot Plug PCI Controller Driver version: 0.4
-[    3.018615] i801_smbus 0000:00:1f.4: SMBus using PCI interrupt
-[    3.019946] RAPL PMU: API unit is 2^-32 Joules, 5 fixed counters, 655360 ms ovfl timer
-[    3.019947] RAPL PMU: hw unit of domain pp0-core 2^-14 Joules
-[    3.019947] RAPL PMU: hw unit of domain package 2^-14 Joules
-[    3.019947] RAPL PMU: hw unit of domain dram 2^-14 Joules
-[    3.019948] RAPL PMU: hw unit of domain pp1-gpu 2^-14 Joules
-[    3.019948] RAPL PMU: hw unit of domain psys 2^-14 Joules
-[    3.029695] AVX2 version of gcm_enc/dec engaged.
-[    3.029696] AES CTR mode by8 optimization enabled
-[    3.032308] Bluetooth: Core ver 2.22
-[    3.032318] NET: Registered protocol family 31
-[    3.032318] Bluetooth: HCI device and connection manager initialized
-[    3.032320] Bluetooth: HCI socket layer initialized
-[    3.032322] Bluetooth: L2CAP socket layer initialized
-[    3.032325] Bluetooth: SCO socket layer initialized
-[    3.032599] ACPI: Smart Battery System [SBS0]: AC Adapter [AC0] (on-line)
-[    3.036176] [drm] Initialized
-[    3.037328] usb 4-1.1: new SuperSpeed USB device number 3 using xhci_hcd
-[    3.043976] intel-lpss 0000:00:15.0: enabling device (0000 -> 0002)
-[    3.058235] idma64 idma64.0: Found Intel integrated DMA 64-bit
-[    3.058362] media: Linux media interface: v0.10
-[    3.059232] hidraw: raw HID events driver (C) Jiri Kosina
-[    3.059804] Bluetooth: HCI UART driver ver 2.3
-[    3.059810] Bluetooth: HCI UART protocol H4 registered
-[    3.059810] Bluetooth: HCI UART protocol BCSP registered
-[    3.059811] Bluetooth: HCI UART protocol LL registered
-[    3.059812] Bluetooth: HCI UART protocol ATH3K registered
-[    3.059813] Bluetooth: HCI UART protocol Three-wire (H5) registered
-[    3.059842] Bluetooth: HCI UART protocol Intel registered
-[    3.059964] hci_bcm BCM2E7C:00: BCM irq: -22
-[    3.059965] hci_bcm BCM2E7C:00: invalid platform data
-[    3.066434] Linux video capture interface: v2.00
-[    3.070026] usbcore: registered new interface driver usbhid
-[    3.070027] usbhid: USB HID core driver
-[    3.072921] uvcvideo: Found UVC 1.50 device iBridge (05ac:8600)
-[    3.073976] intel-lpss 0000:00:19.0: enabling device (0000 -> 0002)
-[    3.076078] uvcvideo: UVC non compliance - GET_DEF(PROBE) not supported. Enabling workaround.
-[    3.077510] uvcvideo: Failed to query (129) UVC probe control : -32 (exp. 34).
-[    3.077549] uvcvideo: Failed to initialize the device (-5).
-[    3.077619] usbcore: registered new interface driver uvcvideo
-[    3.077620] USB Video Class driver (1.1.1)
-[    3.078918] usbcore: registered new interface driver brcmfmac
-[    3.087008] [drm] amdgpu kernel modesetting enabled.
-[    3.087313] hci_bcm: probe of BCM2E7C:00 failed with error -22
-[    3.087335] Bluetooth: HCI UART protocol Broadcom registered
-[    3.087336] Bluetooth: HCI UART protocol QCA registered
-[    3.087337] Bluetooth: HCI UART protocol AG6XX registered
-[    3.087338] Bluetooth: HCI UART protocol Marvell registered
-[    3.087491] Adding 999996k swap on /dev/nvme0n1p5.  Priority:-1 extents:1 across:999996k SSFS
-[    3.088256] EXT4-fs (nvme0n1p6): mounted filesystem with ordered data mode. Opts: data=ordered
-[    3.088834] AMD IOMMUv2 driver by Joerg Roedel <jroedel@suse.de>
-[    3.088835] AMD IOMMUv2 functionality not available on this system
-[    3.091018] CRAT table not found
-[    3.091019] Finished initializing topology ret=0
-[    3.091035] kfd kfd: Initialized module
-[    3.091261] checking generic (b0300000 1cc0000) vs hw (b0000000 10000000)
-[    3.091263] fb: switching to amdgpudrmfb from EFI VGA
-[    3.091285] Console: switching to colour dummy device 80x25
-[    3.091614] [drm] initializing kernel modesetting (POLARIS11 0x1002:0x67EF 0x106B:0x0167 0xEF).
-[    3.091630] [drm] register mmio base: 0x82600000
-[    3.091630] [drm] register mmio size: 262144
-[    3.091634] [drm] doorbell mmio base: 0xC0000000
-[    3.091634] [drm] doorbell mmio size: 2097152
-[    3.091643] [drm] probing gen 2 caps for device 8086:1901 = 261ad03/e
-[    3.091644] [drm] probing mlw for device 8086:1901 = 261ad03
-[    3.091661] [drm] UVD is enabled in VM mode
-[    3.091662] [drm] VCE enabled in VM mode
-[    3.091673] [drm] ACPI VFCT contains a BIOS for 01:00.0 1002:67ef, size 60416
-[    3.091681] ATOM BIOS: Falcon
-[    3.091686] [drm] GPU post is not needed
-[    3.092891] amdgpu 0000:01:00.0: VRAM: 2048M 0x0000000000000000 - 0x000000007FFFFFFF (2048M used)
-[    3.092892] amdgpu 0000:01:00.0: GTT: 2048M 0x0000000080000000 - 0x00000000FFFFFFFF
-[    3.092907] [drm] Detected VRAM RAM=2048M, BAR=256M
-[    3.092907] [drm] RAM width 128bits GDDR5
-[    3.101155] [TTM] Zone  kernel: Available graphics memory: 8165646 kiB
-[    3.101157] [TTM] Zone   dma32: Available graphics memory: 2097152 kiB
-[    3.101157] [TTM] Initializing pool allocator
-[    3.101161] [TTM] Initializing DMA pool allocator
-[    3.101189] [drm] amdgpu: 2048M of VRAM memory ready
-[    3.101190] [drm] amdgpu: 2048M of GTT memory ready.
-[    3.101201] [drm] GART: num cpu pages 524288, num gpu pages 524288
-[    3.102416] [drm] PCIE GART of 2048M enabled (table at 0x0000000000040000).
-[    3.102433] [drm] Supports vblank timestamp caching Rev 2 (21.10.2013).
-[    3.102433] [drm] Driver supports precise vblank timestamp query.
-[    3.102484] amdgpu 0000:01:00.0: amdgpu: using MSI.
-[    3.102500] [drm] amdgpu: irq initialized.
-[    3.102507] Can't find requested voltage id in vdd_dep_on_sclk table!
-[    3.102661] amdgpu: powerplay initialized
-[    3.103971] intel-lpss 0000:00:1e.0: enabling device (0000 -> 0002)
-[    3.104183] (NULL device *): hwmon_device_register() is deprecated. Please convert the driver to use hwmon_device_register_with_info().
-[    3.104190] EXT4-fs (nvme0n1p7): mounted filesystem with ordered data mode. Opts: data=ordered
-[    3.104216] ACPI: Smart Battery System [SBS0]: Battery Slot [BAT0] (battery present)
-[    3.104312] idma64 idma64.2: Found Intel integrated DMA 64-bit
-[    3.104398] intel_rapl: Found RAPL domain package
-[    3.104399] intel_rapl: Found RAPL domain core
-[    3.104399] intel_rapl: Found RAPL domain uncore
-[    3.104400] intel_rapl: Found RAPL domain dram
-[    3.104497] snd_hda_codec_generic hdaudioC0D0: autoconfig for Generic: line_outs=2 (0x24/0x25/0x0/0x0/0x0) type:speaker
-[    3.104499] snd_hda_codec_generic hdaudioC0D0:    speaker_outs=0 (0x0/0x0/0x0/0x0/0x0)
-[    3.104500] snd_hda_codec_generic hdaudioC0D0:    hp_outs=1 (0x2c/0x0/0x0/0x0/0x0)
-[    3.104501] snd_hda_codec_generic hdaudioC0D0:    mono: mono_out=0x0
-[    3.104501] snd_hda_codec_generic hdaudioC0D0:    inputs:
-[    3.104503] snd_hda_codec_generic hdaudioC0D0:      Internal Mic=0x44
-[    3.104504] snd_hda_codec_generic hdaudioC0D0:      Mic=0x3c
-[    3.107072] [drm] amdgpu atom DIG backlight initialized
-[    3.107283] [drm] AMDGPU Display Connectors
-[    3.107284] [drm] Connector 0:
-[    3.107285] [drm]   eDP-1
-[    3.107286] [drm]   HPD1
-[    3.107287] [drm]   DDC: 0x4868 0x4868 0x4869 0x4869 0x486a 0x486a 0x486b 0x486b
-[    3.107289] [drm]   Encoders:
-[    3.107289] [drm]     LCD1: INTERNAL_UNIPHY
-[    3.107290] [drm] Connector 1:
-[    3.107290] [drm]   DP-1
-[    3.107291] [drm]   HPD2
-[    3.107292] [drm]   DDC: 0x486c 0x486c 0x486d 0x486d 0x486e 0x486e 0x486f 0x486f
-[    3.107292] [drm]   Encoders:
-[    3.107293] [drm]     DFP1: INTERNAL_UNIPHY
-[    3.107293] [drm] Connector 2:
-[    3.107294] [drm]   DP-2
-[    3.107294] [drm]   HPD3
-[    3.107295] [drm]   DDC: 0x4870 0x4870 0x4871 0x4871 0x4872 0x4872 0x4873 0x4873
-[    3.107295] [drm]   Encoders:
-[    3.107296] [drm]     DFP2: INTERNAL_UNIPHY1
-[    3.107296] [drm] Connector 3:
-[    3.107297] [drm]   DP-3
-[    3.107297] [drm]   HPD4
-[    3.107298] [drm]   DDC: 0x4874 0x4874 0x4875 0x4875 0x4876 0x4876 0x4877 0x4877
-[    3.107299] [drm]   Encoders:
-[    3.107299] [drm]     DFP3: INTERNAL_UNIPHY1
-[    3.107299] [drm] Connector 4:
-[    3.107300] [drm]   DP-4
-[    3.107300] [drm]   HPD5
-[    3.107301] [drm]   DDC: 0x4878 0x4878 0x4879 0x4879 0x487a 0x487a 0x487b 0x487b
-[    3.107302] [drm]   Encoders:
-[    3.107302] [drm]     DFP4: INTERNAL_UNIPHY2
-[    3.108795] amdgpu 0000:01:00.0: fence driver on ring 0 use gpu addr 0x0000000080000008, cpu addr 0xffff8804612a6008
-[    3.108827] amdgpu 0000:01:00.0: fence driver on ring 1 use gpu addr 0x0000000080000018, cpu addr 0xffff8804612a6018
-[    3.108844] amdgpu 0000:01:00.0: fence driver on ring 2 use gpu addr 0x0000000080000028, cpu addr 0xffff8804612a6028
-[    3.108867] amdgpu 0000:01:00.0: fence driver on ring 3 use gpu addr 0x0000000080000038, cpu addr 0xffff8804612a6038
-[    3.108887] amdgpu 0000:01:00.0: fence driver on ring 4 use gpu addr 0x0000000080000048, cpu addr 0xffff8804612a6048
-[    3.108905] amdgpu 0000:01:00.0: fence driver on ring 5 use gpu addr 0x0000000080000058, cpu addr 0xffff8804612a6058
-[    3.108922] amdgpu 0000:01:00.0: fence driver on ring 6 use gpu addr 0x0000000080000068, cpu addr 0xffff8804612a6068
-[    3.108940] amdgpu 0000:01:00.0: fence driver on ring 7 use gpu addr 0x0000000080000078, cpu addr 0xffff8804612a6078
-[    3.108960] amdgpu 0000:01:00.0: fence driver on ring 8 use gpu addr 0x0000000080000088, cpu addr 0xffff8804612a6088
-[    3.110364] amdgpu 0000:01:00.0: fence driver on ring 9 use gpu addr 0x0000000080000098, cpu addr 0xffff8804612a6098
-[    3.110442] amdgpu 0000:01:00.0: fence driver on ring 10 use gpu addr 0x00000000800000a8, cpu addr 0xffff8804612a60a8
-[    3.111108] [drm] Found UVD firmware Version: 1.79 Family ID: 16
-[    3.111451] amdgpu 0000:01:00.0: fence driver on ring 11 use gpu addr 0x000000000049c420, cpu addr 0xffffc9000265a420
-[    3.111886] [drm] Found VCE firmware Version: 52.4 Binary ID: 3
-[    3.111976] amdgpu 0000:01:00.0: fence driver on ring 12 use gpu addr 0x00000000800000c8, cpu addr 0xffff8804612a60c8
-[    3.112116] amdgpu 0000:01:00.0: fence driver on ring 13 use gpu addr 0x00000000800000d8, cpu addr 0xffff8804612a60d8
-[    3.120629] intel-lpss 0000:00:1e.1: enabling device (0000 -> 0002)
-[    3.120898] idma64 idma64.3: Found Intel integrated DMA 64-bit
-[    3.140622] intel-lpss 0000:00:1e.2: enabling device (0000 -> 0002)
-[    3.140934] idma64 idma64.4: Found Intel integrated DMA 64-bit
-[    3.157407] intel-lpss 0000:00:1e.3: enabling device (0000 -> 0002)
-[    3.157677] idma64 idma64.5: Found Intel integrated DMA 64-bit
-[    3.168140] [AVFS] Something is broken. See log!
-[    3.185230] [drm] ring test on 0 succeeded in 17 usecs
-[    3.185476] [drm] ring test on 1 succeeded in 33 usecs
-[    3.185542] [drm] ring test on 2 succeeded in 33 usecs
-[    3.185577] [drm] ring test on 3 succeeded in 17 usecs
-[    3.185615] [drm] ring test on 4 succeeded in 18 usecs
-[    3.185650] [drm] ring test on 5 succeeded in 17 usecs
-[    3.185687] [drm] ring test on 6 succeeded in 18 usecs
-[    3.185724] [drm] ring test on 7 succeeded in 18 usecs
-[    3.185759] [drm] ring test on 8 succeeded in 17 usecs
-[    3.185806] [drm] ring test on 9 succeeded in 7 usecs
-[    3.185814] [drm] ring test on 10 succeeded in 7 usecs
-[    3.201544] iTCO_vendor_support: vendor-support=0
-[    3.202031] input: Apple Inc. iBridge as /devices/pci0000:00/0000:00:14.0/usb1/1-3/1-3:1.2/0003:05AC:8600.0001/input/input6
-[    3.202114] brcmfmac 0000:03:00.0: Direct firmware load for brcm/brcmfmac43602-pcie.txt failed with error -2
-[    3.202330] iTCO_wdt: Intel TCO WatchDog Timer Driver v1.11
-[    3.203269] iTCO_wdt: unable to reset NO_REBOOT flag, device disabled by hardware/BIOS
-[    3.207154] usbcore: registered new interface driver r8152
-[    3.210421] usbcore: registered new interface driver cdc_ether
-[    3.223112] dw-apb-uart.1: ttyS0 at MMIO 0x8272a000 (irq = 21, base_baud = 115200) is a 16550A
-[    3.233218] [drm] ring test on 11 succeeded in 0 usecs
-[    3.233219] [drm] UVD initialized successfully.
-[    3.241977] dw-apb-uart.2: ttyS1 at MMIO 0x8272b000 (irq = 20, base_baud = 3000000) is a 16550A
-[    3.257871] hid-generic 0003:05AC:8600.0001: input,hidraw0: USB HID v1.01 Keyboard [Apple Inc. iBridge] on usb-0000:00:14.0-3/input2
-[    3.277627] hid-generic 0003:05AC:8600.0002: hiddev0,hidraw1: USB HID v1.01 Device [Apple Inc. iBridge] on usb-0000:00:14.0-3/input3
-[    3.278493] dw-apb-uart.3: ttyS2 at MMIO 0x8272c000 (irq = 21, base_baud = 115200) is a 16550A
-[    3.284187] usb 4-1.1: reset SuperSpeed USB device number 3 using xhci_hcd
-[    3.313953] usb 1-11.4: new full-speed USB device number 4 using xhci_hcd
-[    3.328519] applesmc: key=858 fan=2 temp=46 index=45 acc=0 lux=0 kbd=0
-[    3.328593] applesmc applesmc.768: hwmon_device_register() is deprecated. Please convert the driver to use hwmon_device_register_with_info().
-[    3.333993] [drm] ring test on 12 succeeded in 12 usecs
-[    3.334021] [drm] ring test on 13 succeeded in 10 usecs
-[    3.334022] [drm] VCE initialized successfully.
-[    3.357737] r8152 4-1.1:1.0 eth0: v1.08.8
-[    3.358813] r8152 4-1.1:1.0 enp7s0u1u1: renamed from eth0
-[    3.422533] input: Logitech USB Receiver as /devices/pci0000:00/0000:00:14.0/usb1/1-11/1-11.4/1-11.4:1.0/0003:046D:C534.0003/input/input7
-[    3.441458] random: crng init done
-[    3.477925] [drm] fb mappable at 0xB076F000
-[    3.477926] [drm] vram apper at 0xB0000000
-[    3.477926] [drm] size 20738048
-[    3.477928] hid-generic 0003:046D:C534.0003: input,hidraw2: USB HID v1.11 Keyboard [Logitech USB Receiver] on usb-0000:00:14.0-11.4/input0
-[    3.477928] [drm] fb depth is 24
-[    3.477929] [drm]    pitch is 11520
-[    3.478024] fbcon: amdgpudrmfb (fb0) is primary device
-[    3.480154] input: Logitech USB Receiver as /devices/pci0000:00/0000:00:14.0/usb1/1-11/1-11.4/1-11.4:1.1/0003:046D:C534.0004/input/input8
-[    3.524161] brcmfmac: brcmf_c_preinit_dcmds: Firmware version = wl0: Nov 10 2015 06:38:10 version 7.35.177.61 (r598657) FWID 01-ea662a8c
-[    3.528724] IPv6: ADDRCONF(NETDEV_UP): enp7s0u1u1: link is not ready
-[    3.534472] hid-generic 0003:046D:C534.0004: input,hiddev0,hidraw3: USB HID v1.11 Mouse [Logitech USB Receiver] on usb-0000:00:14.0-11.4/input1
-[    3.542401] mousedev: PS/2 mouse device common for all mice
-[    3.556637] IPv6: ADDRCONF(NETDEV_UP): enp7s0u1u1: link is not ready
-[    3.556705] brcmfmac: brcmf_cfg80211_reg_notifier: not a ISO3166 code (0x30 0x30)
-[    3.564121] brcmfmac 0000:03:00.0 wlp3s0: renamed from wlan0
-[    3.593842] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[    3.638480] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[    4.053236] 
-                failed to send message 5e ret is 0 
-[    4.192824] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[    4.460725] brcmfmac: brcmf_p2p_create_p2pdev: set p2p_disc error
-[    4.460726] brcmfmac: brcmf_cfg80211_add_iface: add iface p2p-dev-wlp3s0 type 10 failed: err=-16
-[    4.463513] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[    4.940519] 
-                failed to send pre message 145 ret is 0 
-[    4.996289] Console: switching to colour frame buffer device 360x112
-[    5.162080] amdgpu 0000:01:00.0: fb0: amdgpudrmfb frame buffer device
-[    5.207982] [drm] ib test on ring 0 succeeded
-[    5.208297] [drm] ib test on ring 1 succeeded
-[    5.208436] [drm] ib test on ring 2 succeeded
-[    5.208574] [drm] ib test on ring 3 succeeded
-[    5.208711] [drm] ib test on ring 4 succeeded
-[    5.208847] [drm] ib test on ring 5 succeeded
-[    5.208983] [drm] ib test on ring 6 succeeded
-[    5.209124] [drm] ib test on ring 7 succeeded
-[    5.209178] [drm] ib test on ring 8 succeeded
-[    5.209210] [drm] ib test on ring 9 succeeded
-[    5.209241] [drm] ib test on ring 10 succeeded
-[    5.211991] [drm] ib test on ring 11 succeeded
-[    6.218277] [drm:amdgpu_vce_ring_test_ib [amdgpu]] *ERROR* amdgpu: IB test timed out.
-[    6.218443] [drm:amdgpu_ib_ring_tests [amdgpu]] *ERROR* amdgpu: failed testing IB on ring 12 (-110).
-[    6.218594] [drm:amdgpu_device_init [amdgpu]] *ERROR* ib ring test failed (-110).
-[    6.219794] [drm] Initialized amdgpu 3.9.0 20150101 for 0000:01:00.0 on minor 0
-[    6.219923] snd_hda_intel 0000:01:00.1: enabling device (0000 -> 0002)
-[    6.220081] snd_hda_intel 0000:01:00.1: Handle vga_switcheroo audio client
-[    6.220085] snd_hda_intel 0000:01:00.1: Force to non-snoop mode
-[    6.233546] input: HDA ATI HDMI HDMI/DP,pcm=3 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card1/input9
-[    6.233613] input: HDA ATI HDMI HDMI/DP,pcm=7 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card1/input10
-[    6.233685] input: HDA ATI HDMI HDMI/DP,pcm=8 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card1/input11
-[    6.233754] input: HDA ATI HDMI HDMI/DP,pcm=9 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card1/input12
-[    6.233813] input: HDA ATI HDMI HDMI/DP,pcm=10 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card1/input13
-[    6.233873] input: HDA ATI HDMI HDMI/DP,pcm=11 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card1/input14
-[    7.163111] r8152 4-1.1:1.0 enp7s0u1u1: carrier on
-[    7.163137] IPv6: ADDRCONF(NETDEV_CHANGE): enp7s0u1u1: link becomes ready
-[    7.513459] fuse init (API version 7.26)
-[   14.781268] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[   14.795949] Bluetooth: BNEP (Ethernet Emulation) ver 1.3
-[   14.795953] Bluetooth: BNEP filters: protocol multicast
-[   14.795960] Bluetooth: BNEP socket layer initialized
-[   18.665432] IPv6: ADDRCONF(NETDEV_CHANGE): wlp3s0: link becomes ready
-[   26.661941] brcmfmac: brcmf_cfg80211_reg_notifier: not a ISO3166 code (0x30 0x30)
-[   64.780249] brcmfmac: brcmf_cfg80211_reg_notifier: not a ISO3166 code (0x30 0x30)
-[   64.785711] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[   65.796102] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[   66.996854] IPv6: ADDRCONF(NETDEV_CHANGE): wlp3s0: link becomes ready
-[   69.070478] brcmfmac: brcmf_inetaddr_changed: fail to get arp ip table err:-23
-[   73.093846] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[   73.094910] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[   73.094983] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[   73.096072] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[   73.555489] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[   73.557727] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  100.858078] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  100.860326] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  109.583812] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  109.594004] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  112.643878] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  121.364204] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  134.143725] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  154.673281] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  199.107188] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  199.108237] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  325.110709] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  325.111636] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  325.249015] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  325.251027] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  326.075272] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  326.273062] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  410.473345] raid6: sse2x1   gen() 10007 MB/s
-[  410.530034] raid6: sse2x1   xor()  8549 MB/s
-[  410.586671] raid6: sse2x2   gen() 15221 MB/s
-[  410.643345] raid6: sse2x2   xor()  9731 MB/s
-[  410.700010] raid6: sse2x4   gen() 15810 MB/s
-[  410.756669] raid6: sse2x4   xor() 11670 MB/s
-[  410.813336] raid6: avx2x1   gen() 24345 MB/s
-[  410.870002] raid6: avx2x1   xor() 17773 MB/s
-[  410.926669] raid6: avx2x2   gen() 27751 MB/s
-[  410.983335] raid6: avx2x2   xor() 19251 MB/s
-[  411.040001] raid6: avx2x4   gen() 28578 MB/s
-[  411.096668] raid6: avx2x4   xor() 23051 MB/s
-[  411.096669] raid6: using algorithm avx2x4 gen() 28578 MB/s
-[  411.096670] raid6: .... xor() 23051 MB/s, rmw enabled
-[  411.096670] raid6: using avx2x2 recovery algorithm
-[  411.102582] xor: automatically using best checksumming function   avx       
-[  411.113399] Btrfs loaded, crc32c=crc32c-intel
-[  411.128366] JFS: nTxBlock = 8192, nTxLock = 65536
-[  411.133316] NILFS version 2 loaded
-[  411.149342] SGI XFS with ACLs, security attributes, realtime, no debug enabled
-[  451.340309] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  451.341428] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  451.406529] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  451.407447] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  451.434827] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  451.611308] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  577.380959] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  577.382074] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  577.665499] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  577.766083] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  577.769410] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  577.774920] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  703.956928] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  703.958029] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  704.130160] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  704.131156] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  704.853761] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  704.951296] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  829.999656] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  830.000829] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  830.079308] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  830.082724] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  830.332900] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  830.492682] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  912.343531] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  912.413262] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  912.731651] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  912.821132] [UFW BLOCK] IN=wlp3s0 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  912.955443] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  914.992716] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  948.822444] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[  956.193295] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[  965.193976] brcmfmac: brcmf_cfg80211_reg_notifier: not a ISO3166 code (0x30 0x30)
-[  980.239856] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[  980.246995] brcmfmac: brcmf_inetaddr_changed: fail to get arp ip table err:-23
-[  980.781830] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[  981.846923] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[ 1004.784357] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 1007.083674] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 1014.978701] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 1082.196285] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 1082.197436] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 1082.224946] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[ 1082.753308] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[ 1083.111795] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 1208.420865] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 1208.421993] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 1208.748358] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 1227.470997] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 1233.451335] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 1240.739172] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 1246.947826] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 1248.817534] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 1306.956455] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 1314.106771] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 1314.337685] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 1334.490331] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 1334.491416] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 1424.751006] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[ 1460.526250] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 1460.527459] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 1460.706641] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 1587.179078] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 1587.180234] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 1588.019351] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 1714.454771] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 1714.455962] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 1715.244484] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 1740.750277] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[ 1840.675997] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 1840.677300] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 1840.784731] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 1967.939348] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 1967.940534] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 1968.973406] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 2056.749638] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[ 2094.262363] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 2094.263653] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 2094.456326] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 2113.831797] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 2221.464869] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 2221.466148] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 2348.723600] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 2348.724927] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 2372.743257] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[ 2475.985301] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 2475.986584] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 2603.241224] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 2603.242516] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 2629.710171] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 2633.110170] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 2648.180013] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 2657.974162] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 2666.457138] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 2688.739734] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[ 2730.000140] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 2730.001251] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 2730.404555] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 2856.020368] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 2856.021502] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 2856.837148] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 2874.149531] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 2874.500251] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 2877.921268] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 2878.320282] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 2878.889942] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 2921.835978] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:c0:ee:fb:dd:4f:e9:08:00 SRC=192.168.0.13 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 2982.086272] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 2982.087311] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 2982.414010] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 3004.740159] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[ 3108.154582] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 3108.155729] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 3108.591525] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 3234.173109] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 3234.174253] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 3234.891572] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 3320.734520] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[ 3360.724803] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 3360.725921] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 3360.910461] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 3486.929642] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 3486.930858] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 3488.269897] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 3613.578118] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 3613.579293] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 3614.129640] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 3636.732953] IPv6: ADDRCONF(NETDEV_UP): wlp3s0: link is not ready
-[ 3739.613590] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 3739.614771] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 3740.167692] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
-[ 3756.499092] ttyS0 - failed to request DMA
-[ 3756.534548] ppdev: user-space parallel port driver
-[ 3756.742740] lp: driver loaded but no devices found
-[ 3756.801270] st: Version 20160209, fixed bufsize 32768, s/g segs 256
-[ 3756.857197] BIOS EDD facility v0.16 2004-Jun-25, 0 devices found
-[ 3756.857197] EDD information not available.
-[ 3866.376882] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=28 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 3866.377945] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:01:b0:b9:8a:0d:72:7a:08:00 SRC=192.168.0.1 DST=224.0.0.1 LEN=32 TOS=0x00 PREC=0x00 TTL=1 ID=0 PROTO=2 
-[ 3867.094305] [UFW BLOCK] IN=enp7s0u1u1 OUT= MAC=01:00:5e:00:00:fb:a4:77:33:eb:d2:34:08:00 SRC=192.168.0.14 DST=224.0.0.251 LEN=32 TOS=0x00 PREC=0xC0 TTL=1 ID=0 DF PROTO=2 
+[    0.000000] DMI: Apple Inc. MacBookPro13,3/Mac-A5C67F76ED83108C, BIOS 263.0.0.0.0 10/30/2019
+[    0.000000] tsc: Detected 2900.000 MHz processor
+[    0.001065] tsc: Detected 2899.886 MHz TSC
+[    0.001065] e820: update [mem 0x00000000-0x00000fff] usable ==> reserved
+[    0.001066] e820: remove [mem 0x000a0000-0x000fffff] usable
+[    0.001072] last_pfn = 0x47f000 max_arch_pfn = 0x400000000
+[    0.001074] MTRR default type: write-back
+[    0.001075] MTRR fixed ranges enabled:
+[    0.001076]   00000-9FFFF write-back
+[    0.001077]   A0000-BFFFF uncachable
+[    0.001077]   C0000-DFFFF write-protect
+[    0.001078]   E0000-FFFFF uncachable
+[    0.001078] MTRR variable ranges enabled:
+[    0.001079]   0 base 0080000000 mask 7F80000000 uncachable
+[    0.001080]   1 base 007C000000 mask 7FFC000000 uncachable
+[    0.001080]   2 base 007B000000 mask 7FFF000000 uncachable
+[    0.001081]   3 base 4000000000 mask 4000000000 uncachable
+[    0.001082]   4 disabled
+[    0.001082]   5 disabled
+[    0.001082]   6 disabled
+[    0.001082]   7 disabled
+[    0.001083]   8 disabled
+[    0.001083]   9 disabled
+[    0.001381] x86/PAT: Configuration [0-7]: WB  WC  UC- UC  WB  WP  UC- WT  
+[    0.001504] last_pfn = 0x7b000 max_arch_pfn = 0x400000000
+[    0.012514] check: Scanning 1 areas for low memory corruption
+[    0.012529] Using GB pages for direct mapping
+[    0.012531] BRK [0x263001000, 0x263001fff] PGTABLE
+[    0.012532] BRK [0x263002000, 0x263002fff] PGTABLE
+[    0.012533] BRK [0x263003000, 0x263003fff] PGTABLE
+[    0.012557] BRK [0x263004000, 0x263004fff] PGTABLE
+[    0.012558] BRK [0x263005000, 0x263005fff] PGTABLE
+[    0.012631] BRK [0x263006000, 0x263006fff] PGTABLE
+[    0.012650] BRK [0x263007000, 0x263007fff] PGTABLE
+[    0.012693] BRK [0x263008000, 0x263008fff] PGTABLE
+[    0.012718] BRK [0x263009000, 0x263009fff] PGTABLE
+[    0.012750] BRK [0x26300a000, 0x26300afff] PGTABLE
+[    0.012800] BRK [0x26300b000, 0x26300bfff] PGTABLE
+[    0.012837] BRK [0x26300c000, 0x26300cfff] PGTABLE
+[    0.012862] Secure boot disabled
+[    0.012863] RAMDISK: [mem 0x3c06c000-0x3fffdfff]
+[    0.012879] ACPI: Early table checksum verification disabled
+[    0.012881] ACPI: RSDP 0x000000007AFFE014 000024 (v02 APPLE )
+[    0.012884] ACPI: XSDT 0x000000007AFC6188 0000D4 (v01 APPLE  Apple00  00000000      01000013)
+[    0.012888] ACPI: FACP 0x000000007AFF8000 0000F4 (v05 APPLE  Apple00  00000000 Loki 0000005F)
+[    0.012891] ACPI: DSDT 0x000000007AFEB000 0086AB (v02 APPLE  MacBookP 00150001 INTL 20140424)
+[    0.012893] ACPI: FACS 0x000000007AF9B000 000040
+[    0.012895] ACPI: UEFI 0x000000007AF9D000 000042 (v01 INTEL  EDK2     00000002      01000013)
+[    0.012897] ACPI: ECDT 0x000000007AFFA000 000053 (v01 APPLE  Apple00  00000001 Loki 0000005F)
+[    0.012899] ACPI: HPET 0x000000007AFF7000 000038 (v01 APPLE  Apple00  00000001 Loki 0000005F)
+[    0.012901] ACPI: APIC 0x000000007AFF6000 0000BC (v02 APPLE  Apple00  00000001 Loki 0000005F)
+[    0.012903] ACPI: MCFG 0x000000007AFF5000 00003C (v01 APPLE  Apple00  00000001 Loki 0000005F)
+[    0.012904] ACPI: SBST 0x000000007AFF4000 000030 (v01 APPLE  Apple00  00000001 Loki 0000005F)
+[    0.012906] ACPI: SSDT 0x000000007AFEA000 000024 (v01 APPLE  SmcDppt  00001000 INTL 20140424)
+[    0.012908] ACPI: SSDT 0x000000007AFE9000 0007FD (v02 APPLE  PEG0GFX0 00001000 INTL 20140424)
+[    0.012910] ACPI: SSDT 0x000000007AFE8000 000024 (v01 APPLE  PEG0SSD0 00001000 INTL 20140424)
+[    0.012912] ACPI: SSDT 0x000000007AFE5000 000031 (v01 APPLE  SsdtS3   00001000 INTL 20140424)
+[    0.012914] ACPI: SSDT 0x000000007AFE4000 0000DD (v01 APPLE  SataAhci 00001000 INTL 20140424)
+[    0.012916] ACPI: SSDT 0x000000007AFE3000 0000B8 (v01 APPLE  Sdxc     00001000 INTL 20140424)
+[    0.012918] ACPI: SSDT 0x000000007AFCE000 00996E (v02 APPLE  TbtPEG12 00001000 INTL 20140424)
+[    0.012920] ACPI: SSDT 0x000000007AFCD000 000C97 (v02 APPLE  Xhci     00001000 INTL 20140424)
+[    0.012922] ACPI: SSDT 0x000000007AFCC000 000612 (v02 PmRef  Cpu0Ist  00003000 INTL 20140424)
+[    0.012924] ACPI: SSDT 0x000000007AFCB000 0005AA (v02 PmRef  ApIst    00003000 INTL 20140424)
+[    0.012925] ACPI: SSDT 0x000000007AFCA000 000295 (v02 PmRef  Cpu0Cst  00003001 INTL 20140424)
+[    0.012927] ACPI: SSDT 0x000000007AFC9000 000119 (v02 PmRef  ApCst    00003000 INTL 20140424)
+[    0.012929] ACPI: SSDT 0x000000007AFC8000 000EEF (v02 CpuRef CpuSsdt  00003000 INTL 20140424)
+[    0.012931] ACPI: DMAR 0x000000007AFC7000 000160 (v01 APPLE  SKL      00000001 INTL 00000001)
+[    0.012933] ACPI: VFCT 0x000000007AFB7000 00E884 (v01 APPLE  Apple00  00000001 AMD  31504F47)
+[    0.012938] ACPI: DMI detected to setup _OSI("Darwin"): Apple hardware
+[    0.012940] ACPI: Local APIC address 0xfee00000
+[    0.013212] No NUMA configuration found
+[    0.013212] Faking a node at [mem 0x0000000000000000-0x000000047effffff]
+[    0.013221] NODE_DATA(0) allocated [mem 0x47efd6000-0x47effffff]
+[    0.013386] Zone ranges:
+[    0.013387]   DMA      [mem 0x0000000000001000-0x0000000000ffffff]
+[    0.013388]   DMA32    [mem 0x0000000001000000-0x00000000ffffffff]
+[    0.013388]   Normal   [mem 0x0000000100000000-0x000000047effffff]
+[    0.013389]   Device   empty
+[    0.013390] Movable zone start for each node
+[    0.013392] Early memory node ranges
+[    0.013393]   node   0: [mem 0x0000000000001000-0x0000000000057fff]
+[    0.013393]   node   0: [mem 0x0000000000059000-0x000000000009dfff]
+[    0.013394]   node   0: [mem 0x0000000000100000-0x0000000074021fff]
+[    0.013394]   node   0: [mem 0x0000000074374000-0x0000000074e04fff]
+[    0.013395]   node   0: [mem 0x0000000074e50000-0x000000007507dfff]
+[    0.013395]   node   0: [mem 0x000000007507f000-0x000000007ac7efff]
+[    0.013395]   node   0: [mem 0x000000007afff000-0x000000007affffff]
+[    0.013396]   node   0: [mem 0x0000000100000000-0x000000047effffff]
+[    0.013574] Zeroed struct page in unavailable ranges: 26498 pages
+[    0.013575] Initmem setup node 0 [mem 0x0000000000001000-0x000000047effffff]
+[    0.013576] On node 0 totalpages: 4167806
+[    0.013576]   DMA zone: 64 pages used for memmap
+[    0.013577]   DMA zone: 21 pages reserved
+[    0.013577]   DMA zone: 3996 pages, LIFO batch:0
+[    0.013616]   DMA32 zone: 7780 pages used for memmap
+[    0.013617]   DMA32 zone: 497890 pages, LIFO batch:63
+[    0.020639]   Normal zone: 57280 pages used for memmap
+[    0.020639]   Normal zone: 3665920 pages, LIFO batch:63
+[    0.054252] ACPI: PM-Timer IO Port: 0x1808
+[    0.054253] ACPI: Local APIC address 0xfee00000
+[    0.054258] ACPI: LAPIC_NMI (acpi_id[0x01] high edge lint[0x1])
+[    0.054259] ACPI: LAPIC_NMI (acpi_id[0x02] high edge lint[0x1])
+[    0.054259] ACPI: LAPIC_NMI (acpi_id[0x03] high edge lint[0x1])
+[    0.054259] ACPI: LAPIC_NMI (acpi_id[0x04] high edge lint[0x1])
+[    0.054260] ACPI: LAPIC_NMI (acpi_id[0x05] high edge lint[0x1])
+[    0.054260] ACPI: LAPIC_NMI (acpi_id[0x06] high edge lint[0x1])
+[    0.054261] ACPI: LAPIC_NMI (acpi_id[0x07] high edge lint[0x1])
+[    0.054261] ACPI: LAPIC_NMI (acpi_id[0x08] high edge lint[0x1])
+[    0.054296] IOAPIC[0]: apic_id 2, version 32, address 0xfec00000, GSI 0-23
+[    0.054298] ACPI: INT_SRC_OVR (bus 0 bus_irq 0 global_irq 2 dfl dfl)
+[    0.054299] ACPI: INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
+[    0.054300] ACPI: IRQ0 used by override.
+[    0.054300] ACPI: IRQ9 used by override.
+[    0.054302] Using ACPI (MADT) for SMP configuration information
+[    0.054303] ACPI: HPET id: 0x8086a201 base: 0xfed00000
+[    0.054305] smpboot: Allowing 8 CPUs, 0 hotplug CPUs
+[    0.054319] PM: Registered nosave memory: [mem 0x00000000-0x00000fff]
+[    0.054320] PM: Registered nosave memory: [mem 0x00058000-0x00058fff]
+[    0.054321] PM: Registered nosave memory: [mem 0x0009e000-0x000fffff]
+[    0.054322] PM: Registered nosave memory: [mem 0x7396a000-0x7396afff]
+[    0.054323] PM: Registered nosave memory: [mem 0x7397b000-0x7397bfff]
+[    0.054324] PM: Registered nosave memory: [mem 0x7397c000-0x7397cfff]
+[    0.054325] PM: Registered nosave memory: [mem 0x7398a000-0x7398afff]
+[    0.054326] PM: Registered nosave memory: [mem 0x74022000-0x74373fff]
+[    0.054327] PM: Registered nosave memory: [mem 0x74e05000-0x74e05fff]
+[    0.054327] PM: Registered nosave memory: [mem 0x74e06000-0x74e4ffff]
+[    0.054328] PM: Registered nosave memory: [mem 0x7507e000-0x7507efff]
+[    0.054329] PM: Registered nosave memory: [mem 0x7ac7f000-0x7af4efff]
+[    0.054330] PM: Registered nosave memory: [mem 0x7af4f000-0x7af9efff]
+[    0.054330] PM: Registered nosave memory: [mem 0x7af9f000-0x7affefff]
+[    0.054331] PM: Registered nosave memory: [mem 0x7b000000-0x7fffffff]
+[    0.054332] PM: Registered nosave memory: [mem 0x80000000-0xe00f9fff]
+[    0.054332] PM: Registered nosave memory: [mem 0xe00fa000-0xe00fafff]
+[    0.054332] PM: Registered nosave memory: [mem 0xe00fb000-0xe00fcfff]
+[    0.054333] PM: Registered nosave memory: [mem 0xe00fd000-0xe00fdfff]
+[    0.054333] PM: Registered nosave memory: [mem 0xe00fe000-0xfdffffff]
+[    0.054333] PM: Registered nosave memory: [mem 0xfe000000-0xfe010fff]
+[    0.054334] PM: Registered nosave memory: [mem 0xfe011000-0xff938fff]
+[    0.054334] PM: Registered nosave memory: [mem 0xff939000-0xff968fff]
+[    0.054334] PM: Registered nosave memory: [mem 0xff969000-0xffffffff]
+[    0.054336] [mem 0x80000000-0xe00f9fff] available for PCI devices
+[    0.054336] Booting paravirtualized kernel on bare hardware
+[    0.054339] clocksource: refined-jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645519600211568 ns
+[    0.054343] setup_percpu: NR_CPUS:8192 nr_cpumask_bits:8 nr_cpu_ids:8 nr_node_ids:1
+[    0.054469] percpu: Embedded 57 pages/cpu s196608 r8192 d28672 u262144
+[    0.054474] pcpu-alloc: s196608 r8192 d28672 u262144 alloc=1*2097152
+[    0.054474] pcpu-alloc: [0] 0 1 2 3 4 5 6 7 
+[    0.054494] Built 1 zonelists, mobility grouping on.  Total pages: 4102661
+[    0.054495] Policy zone: Normal
+[    0.054496] Kernel command line: BOOT_IMAGE=/boot/vmlinuz-5.5.11-050511-generic root=UUID=a4e17617-b04c-4225-94aa-54075e40190a ro quiet splash vt.handoff=1
+[    0.055113] Dentry cache hash table entries: 2097152 (order: 12, 16777216 bytes, linear)
+[    0.055385] Inode-cache hash table entries: 1048576 (order: 11, 8388608 bytes, linear)
+[    0.055444] mem auto-init: stack:off, heap alloc:on, heap free:off
+[    0.085688] Memory: 16071996K/16671224K available (14339K kernel code, 2410K rwdata, 5168K rodata, 2664K init, 5032K bss, 599228K reserved, 0K cma-reserved)
+[    0.085779] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=8, Nodes=1
+[    0.085788] Kernel/User page tables isolation: enabled
+[    0.085798] ftrace: allocating 44712 entries in 175 pages
+[    0.098835] ftrace: allocated 175 pages with 6 groups
+[    0.098919] rcu: Hierarchical RCU implementation.
+[    0.098920] rcu: 	RCU restricting CPUs from NR_CPUS=8192 to nr_cpu_ids=8.
+[    0.098920] 	Tasks RCU enabled.
+[    0.098921] rcu: RCU calculated value of scheduler-enlistment delay is 25 jiffies.
+[    0.098921] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=8
+[    0.101047] NR_IRQS: 524544, nr_irqs: 488, preallocated irqs: 16
+[    0.101361] random: crng done (trusting CPU's manufacturer)
+[    0.101381] Console: colour dummy device 80x25
+[    0.101385] printk: console [tty0] enabled
+[    0.101396] ACPI: Core revision 20191018
+[    0.101623] clocksource: hpet: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 79635855245 ns
+[    0.101694] APIC: Switch to symmetric I/O mode setup
+[    0.101696] DMAR: Host address width 39
+[    0.101697] DMAR: DRHD base: 0x000000fed90000 flags: 0x0
+[    0.101700] DMAR: dmar0: reg_base_addr fed90000 ver 1:0 cap 1c0000c40660462 ecap 7e3ff0501e
+[    0.101701] DMAR: DRHD base: 0x000000fed91000 flags: 0x1
+[    0.101703] DMAR: dmar1: reg_base_addr fed91000 ver 1:0 cap d2008c40660462 ecap f050da
+[    0.101704] DMAR: RMRR base: 0x0000007b800000 end: 0x0000007fffffff
+[    0.101705] DMAR: ANDD device: 1 name: \_SB.PCI0.I2C0
+[    0.101705] DMAR: ANDD device: 7 name: \_SB.PCI0.SPI0
+[    0.101706] DMAR: ANDD device: 8 name: \_SB.PCI0.SPI1
+[    0.101706] DMAR: ANDD device: 9 name: \_SB.PCI0.UA00
+[    0.101706] DMAR: ANDD device: a name: \_SB.PCI0.UA01
+[    0.101707] DMAR: ANDD device: b name: \_SB.PCI0.UA02
+[    0.101709] DMAR-IR: IOAPIC id 2 under DRHD base  0xfed91000 IOMMU 1
+[    0.101709] DMAR-IR: HPET id 0 under DRHD base 0xfed91000
+[    0.101709] DMAR-IR: Queued invalidation will be enabled to support x2apic and Intr-remapping.
+[    0.102215] DMAR-IR: Enabled IRQ remapping in x2apic mode
+[    0.102216] x2apic enabled
+[    0.102228] Switched APIC routing to cluster x2apic.
+[    0.103243] ..TIMER: vector=0x30 apic1=0 pin1=2 apic2=-1 pin2=-1
+[    0.121700] clocksource: tsc-early: mask: 0xffffffffffffffff max_cycles: 0x29ccd767b87, max_idle_ns: 440795223720 ns
+[    0.121703] Calibrating delay loop (skipped), value calculated using timer frequency.. 5799.77 BogoMIPS (lpj=11599544)
+[    0.121705] pid_max: default: 32768 minimum: 301
+[    0.131210] LSM: Security Framework initializing
+[    0.131218] Yama: becoming mindful.
+[    0.131235] AppArmor: AppArmor initialized
+[    0.131279] Mount-cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
+[    0.131302] Mountpoint-cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
+[    0.131313] *** VALIDATE tmpfs ***
+[    0.131418] *** VALIDATE proc ***
+[    0.131454] *** VALIDATE cgroup1 ***
+[    0.131455] *** VALIDATE cgroup2 ***
+[    0.131496] mce: CPU0: Thermal monitoring enabled (TM1)
+[    0.131511] process: using mwait in idle threads
+[    0.131513] Last level iTLB entries: 4KB 64, 2MB 8, 4MB 8
+[    0.131513] Last level dTLB entries: 4KB 64, 2MB 0, 4MB 0, 1GB 4
+[    0.131515] Spectre V1 : Mitigation: usercopy/swapgs barriers and __user pointer sanitization
+[    0.131516] Spectre V2 : Mitigation: Full generic retpoline
+[    0.131517] Spectre V2 : Spectre v2 / SpectreRSB mitigation: Filling RSB on context switch
+[    0.131517] Spectre V2 : Enabling Restricted Speculation for firmware calls
+[    0.131518] Spectre V2 : mitigation: Enabling conditional Indirect Branch Prediction Barrier
+[    0.131518] Spectre V2 : User space: Mitigation: STIBP via seccomp and prctl
+[    0.131519] Speculative Store Bypass: Mitigation: Speculative Store Bypass disabled via prctl and seccomp
+[    0.131521] TAA: Mitigation: Clear CPU buffers
+[    0.131522] MDS: Mitigation: Clear CPU buffers
+[    0.131714] Freeing SMP alternatives memory: 36K
+[    0.133281] TSC deadline timer enabled
+[    0.133285] smpboot: CPU0: Intel(R) Core(TM) i7-6920HQ CPU @ 2.90GHz (family: 0x6, model: 0x5e, stepping: 0x3)
+[    0.133357] Performance Events: PEBS fmt3+, Skylake events, 32-deep LBR, full-width counters, Intel PMU driver.
+[    0.133361] ... version:                4
+[    0.133361] ... bit width:              48
+[    0.133361] ... generic registers:      4
+[    0.133362] ... value mask:             0000ffffffffffff
+[    0.133362] ... max period:             00007fffffffffff
+[    0.133363] ... fixed-purpose events:   3
+[    0.133363] ... event mask:             000000070000000f
+[    0.133391] rcu: Hierarchical SRCU implementation.
+[    0.133701] NMI watchdog: Enabled. Permanently consumes one hw-PMU counter.
+[    0.133701] smp: Bringing up secondary CPUs ...
+[    0.133701] x86: Booting SMP configuration:
+[    0.133701] .... node  #0, CPUs:      #1 #2 #3 #4
+[    0.135344] MDS CPU bug present and SMT on, data leak possible. See https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html for more details.
+[    0.135344] TAA CPU bug present and SMT on, data leak possible. See https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/tsx_async_abort.html for more details.
+[    0.135344]  #5 #6 #7
+[    0.138130] smp: Brought up 1 node, 8 CPUs
+[    0.138130] smpboot: Max logical packages: 1
+[    0.138130] smpboot: Total of 8 processors activated (46398.17 BogoMIPS)
+[    0.140297] devtmpfs: initialized
+[    0.140297] x86/mm: Memory block size: 128MB
+[    0.142334] PM: Registering ACPI NVS region [mem 0x74e05000-0x74e05fff] (4096 bytes)
+[    0.142334] PM: Registering ACPI NVS region [mem 0x7af4f000-0x7af9efff] (327680 bytes)
+[    0.142334] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
+[    0.142334] futex hash table entries: 2048 (order: 5, 131072 bytes, linear)
+[    0.142334] pinctrl core: initialized pinctrl subsystem
+[    0.142334] PM: RTC time: 18:15:32, date: 2020-06-14
+[    0.142334] thermal_sys: Registered thermal governor 'fair_share'
+[    0.142334] thermal_sys: Registered thermal governor 'bang_bang'
+[    0.142334] thermal_sys: Registered thermal governor 'step_wise'
+[    0.142334] thermal_sys: Registered thermal governor 'user_space'
+[    0.142334] NET: Registered protocol family 16
+[    0.142334] audit: initializing netlink subsys (disabled)
+[    0.142334] audit: type=2000 audit(1592158532.044:1): state=initialized audit_enabled=0 res=1
+[    0.142334] EISA bus registered
+[    0.142334] cpuidle: using governor ladder
+[    0.142334] cpuidle: using governor menu
+[    0.142334] ACPI FADT declares the system doesn't support PCIe ASPM, so disable it
+[    0.142334] ACPI: bus type PCI registered
+[    0.142334] acpiphp: ACPI Hot Plug PCI Controller Driver version: 0.5
+[    0.142334] PCI: MMCONFIG for domain 0000 [bus 00-ff] at [mem 0xe0000000-0xefffffff] (base 0xe0000000)
+[    0.142334] PCI: not using MMCONFIG
+[    0.142334] PCI: Using configuration type 1 for base access
+[    0.142393] ENERGY_PERF_BIAS: Set to 'normal', was 'performance'
+[    0.142521] HugeTLB registered 1.00 GiB page size, pre-allocated 0 pages
+[    0.142521] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
+[    0.145757] ACPI: Disabled all _OSI OS vendors
+[    0.145757] ACPI: Added _OSI(Module Device)
+[    0.145758] ACPI: Added _OSI(Processor Device)
+[    0.145758] ACPI: Added _OSI(3.0 _SCP Extensions)
+[    0.145759] ACPI: Added _OSI(Processor Aggregator Device)
+[    0.145760] ACPI: Added _OSI(Linux-Dell-Video)
+[    0.145760] ACPI: Added _OSI(Linux-Lenovo-NV-HDMI-Audio)
+[    0.145761] ACPI: Added _OSI(Linux-HPI-Hybrid-Graphics)
+[    0.145761] ACPI: Added _OSI(Darwin)
+[    0.158938] ACPI: 14 ACPI AML tables successfully acquired and loaded
+[    0.159936] ACPI: EC: EC started
+[    0.159936] ACPI: EC: interrupt blocked
+[    0.162113] ACPI: \: Used as first EC
+[    0.162114] ACPI: \: GPE=0x7, IRQ=-1, EC_CMD/EC_SC=0x66, EC_DATA=0x62
+[    0.162115] ACPI: EC: Boot ECDT EC used to handle transactions
+[    0.162448] ACPI: BIOS _OSI(Darwin) query honored via DMI
+[    0.163301] ACPI: [Firmware Bug]: BIOS _OSI(Linux) query ignored
+[    0.163844] ACPI: Dynamic OEM Table Load:
+[    0.163853] ACPI Error: AE_ALREADY_EXISTS, SSDT 0xFFFF98DFECBD2800 Table is already loaded (20191018/tbdata-520)
+[    0.163860] fbcon: Taking over console
+[    0.163865] No Local Variables are initialized for Method [GCAP]
+[    0.163865] Initialized Arguments for Method [GCAP]:  (1 arguments defined for method invocation)
+[    0.163866]   Arg0:   00000000e5bc4772 <Obj>           Buffer(8) 00 00 00 00 00 10 00 00
+[    0.163871] ACPI Error: Aborting method \_PR.CPU0.GCAP due to previous error (AE_ALREADY_EXISTS) (20191018/psparse-529)
+[    0.163879] ACPI Error: Aborting method \_PR.CPU0._OSC due to previous error (AE_ALREADY_EXISTS) (20191018/psparse-529)
+[    0.163882] ACPI: Marking method _OSC as Serialized because of AE_ALREADY_EXISTS error
+[    0.164117] ACPI BIOS Error (bug): Could not resolve symbol [\_SB.OSCP], AE_NOT_FOUND (20191018/psargs-330)
+[    0.164122] No Local Variables are initialized for Method [GCAP]
+[    0.164123] Initialized Arguments for Method [GCAP]:  (1 arguments defined for method invocation)
+[    0.164124]   Arg0:   00000000e135973b <Obj>           Buffer(8) 00 00 00 00 00 10 00 00
+[    0.164127] ACPI Error: Aborting method \_PR.CPU1.GCAP due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.164131] ACPI Error: Aborting method \_PR.CPU1._OSC due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.164365] ACPI BIOS Error (bug): Could not resolve symbol [\_SB.OSCP], AE_NOT_FOUND (20191018/psargs-330)
+[    0.164370] No Local Variables are initialized for Method [GCAP]
+[    0.164370] Initialized Arguments for Method [GCAP]:  (1 arguments defined for method invocation)
+[    0.164371]   Arg0:   0000000097cd46aa <Obj>           Buffer(8) 00 00 00 00 00 10 00 00
+[    0.164374] ACPI Error: Aborting method \_PR.CPU2.GCAP due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.164378] ACPI Error: Aborting method \_PR.CPU2._OSC due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.164610] ACPI BIOS Error (bug): Could not resolve symbol [\_SB.OSCP], AE_NOT_FOUND (20191018/psargs-330)
+[    0.164615] No Local Variables are initialized for Method [GCAP]
+[    0.164616] Initialized Arguments for Method [GCAP]:  (1 arguments defined for method invocation)
+[    0.164616]   Arg0:   00000000fd292c74 <Obj>           Buffer(8) 00 00 00 00 00 10 00 00
+[    0.164619] ACPI Error: Aborting method \_PR.CPU3.GCAP due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.164623] ACPI Error: Aborting method \_PR.CPU3._OSC due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.164856] ACPI BIOS Error (bug): Could not resolve symbol [\_SB.OSCP], AE_NOT_FOUND (20191018/psargs-330)
+[    0.164861] No Local Variables are initialized for Method [GCAP]
+[    0.164862] Initialized Arguments for Method [GCAP]:  (1 arguments defined for method invocation)
+[    0.164862]   Arg0:   00000000e82e118c <Obj>           Buffer(8) 00 00 00 00 00 10 00 00
+[    0.164865] ACPI Error: Aborting method \_PR.CPU4.GCAP due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.164869] ACPI Error: Aborting method \_PR.CPU4._OSC due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.165101] ACPI BIOS Error (bug): Could not resolve symbol [\_SB.OSCP], AE_NOT_FOUND (20191018/psargs-330)
+[    0.165106] No Local Variables are initialized for Method [GCAP]
+[    0.165107] Initialized Arguments for Method [GCAP]:  (1 arguments defined for method invocation)
+[    0.165107]   Arg0:   00000000a4616362 <Obj>           Buffer(8) 00 00 00 00 00 10 00 00
+[    0.165110] ACPI Error: Aborting method \_PR.CPU5.GCAP due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.165114] ACPI Error: Aborting method \_PR.CPU5._OSC due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.165346] ACPI BIOS Error (bug): Could not resolve symbol [\_SB.OSCP], AE_NOT_FOUND (20191018/psargs-330)
+[    0.165351] No Local Variables are initialized for Method [GCAP]
+[    0.165352] Initialized Arguments for Method [GCAP]:  (1 arguments defined for method invocation)
+[    0.165352]   Arg0:   00000000578c3255 <Obj>           Buffer(8) 00 00 00 00 00 10 00 00
+[    0.165355] ACPI Error: Aborting method \_PR.CPU6.GCAP due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.165359] ACPI Error: Aborting method \_PR.CPU6._OSC due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.165591] ACPI BIOS Error (bug): Could not resolve symbol [\_SB.OSCP], AE_NOT_FOUND (20191018/psargs-330)
+[    0.165596] No Local Variables are initialized for Method [GCAP]
+[    0.165596] Initialized Arguments for Method [GCAP]:  (1 arguments defined for method invocation)
+[    0.165597]   Arg0:   0000000012d602f1 <Obj>           Buffer(8) 00 00 00 00 00 10 00 00
+[    0.165600] ACPI Error: Aborting method \_PR.CPU7.GCAP due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.165604] ACPI Error: Aborting method \_PR.CPU7._OSC due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.166238] ACPI: Dynamic OEM Table Load:
+[    0.166242] ACPI Error: AE_ALREADY_EXISTS, SSDT 0xFFFF98DFEC77A800 Table is already loaded (20191018/tbdata-520)
+[    0.166247] No Local Variables are initialized for Method [GCAP]
+[    0.166248] Initialized Arguments for Method [GCAP]:  (1 arguments defined for method invocation)
+[    0.166248]   Arg0:   000000002da3d9ca <Obj>           Buffer(12) 00 00 00 00 BF 0B 00 00
+[    0.166252] ACPI Error: Aborting method \_PR.CPU0.GCAP due to previous error (AE_ALREADY_EXISTS) (20191018/psparse-529)
+[    0.166262] ACPI Error: Aborting method \_PR.CPU0._PDC due to previous error (AE_ALREADY_EXISTS) (20191018/psparse-529)
+[    0.166265] ACPI: Marking method _PDC as Serialized because of AE_ALREADY_EXISTS error
+[    0.166660] ACPI: Dynamic OEM Table Load:
+[    0.166665] ACPI Error: AE_ALREADY_EXISTS, SSDT 0xFFFF98DFECBD4000 Table is already loaded (20191018/tbdata-520)
+[    0.166670] No Local Variables are initialized for Method [APPT]
+[    0.166670] No Arguments are initialized for method [APPT]
+[    0.166671] ACPI Error: Aborting method \_PR.CPU1.APPT due to previous error (AE_ALREADY_EXISTS) (20191018/psparse-529)
+[    0.166680] ACPI Error: Aborting method \_PR.CPU1.GCAP due to previous error (AE_ALREADY_EXISTS) (20191018/psparse-529)
+[    0.166685] ACPI Error: Aborting method \_PR.CPU1._PDC due to previous error (AE_ALREADY_EXISTS) (20191018/psparse-529)
+[    0.166688] ACPI: Marking method _PDC as Serialized because of AE_ALREADY_EXISTS error
+[    0.166969] ACPI BIOS Error (bug): Could not resolve symbol [\_SB.OSCP], AE_NOT_FOUND (20191018/psargs-330)
+[    0.166974] No Local Variables are initialized for Method [GCAP]
+[    0.166975] Initialized Arguments for Method [GCAP]:  (1 arguments defined for method invocation)
+[    0.166976]   Arg0:   00000000c67c9be6 <Obj>           Buffer(12) 00 00 00 00 BF 0B 00 00
+[    0.166979] ACPI Error: Aborting method \_PR.CPU2.GCAP due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.166983] ACPI Error: Aborting method \_PR.CPU2._PDC due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.167266] ACPI BIOS Error (bug): Could not resolve symbol [\_SB.OSCP], AE_NOT_FOUND (20191018/psargs-330)
+[    0.167271] No Local Variables are initialized for Method [GCAP]
+[    0.167272] Initialized Arguments for Method [GCAP]:  (1 arguments defined for method invocation)
+[    0.167272]   Arg0:   00000000572bdeac <Obj>           Buffer(12) 00 00 00 00 BF 0B 00 00
+[    0.167275] ACPI Error: Aborting method \_PR.CPU3.GCAP due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.167279] ACPI Error: Aborting method \_PR.CPU3._PDC due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.167560] ACPI BIOS Error (bug): Could not resolve symbol [\_SB.OSCP], AE_NOT_FOUND (20191018/psargs-330)
+[    0.167565] No Local Variables are initialized for Method [GCAP]
+[    0.167565] Initialized Arguments for Method [GCAP]:  (1 arguments defined for method invocation)
+[    0.167566]   Arg0:   00000000533c20c7 <Obj>           Buffer(12) 00 00 00 00 BF 0B 00 00
+[    0.167569] ACPI Error: Aborting method \_PR.CPU4.GCAP due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.167573] ACPI Error: Aborting method \_PR.CPU4._PDC due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.167852] ACPI BIOS Error (bug): Could not resolve symbol [\_SB.OSCP], AE_NOT_FOUND (20191018/psargs-330)
+[    0.167858] No Local Variables are initialized for Method [GCAP]
+[    0.167858] Initialized Arguments for Method [GCAP]:  (1 arguments defined for method invocation)
+[    0.167859]   Arg0:   0000000087e9e706 <Obj>           Buffer(12) 00 00 00 00 BF 0B 00 00
+[    0.167862] ACPI Error: Aborting method \_PR.CPU5.GCAP due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.167866] ACPI Error: Aborting method \_PR.CPU5._PDC due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.168144] ACPI BIOS Error (bug): Could not resolve symbol [\_SB.OSCP], AE_NOT_FOUND (20191018/psargs-330)
+[    0.168149] No Local Variables are initialized for Method [GCAP]
+[    0.168150] Initialized Arguments for Method [GCAP]:  (1 arguments defined for method invocation)
+[    0.168150]   Arg0:   0000000086c8c8f1 <Obj>           Buffer(12) 00 00 00 00 BF 0B 00 00
+[    0.168153] ACPI Error: Aborting method \_PR.CPU6.GCAP due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.168157] ACPI Error: Aborting method \_PR.CPU6._PDC due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.168436] ACPI BIOS Error (bug): Could not resolve symbol [\_SB.OSCP], AE_NOT_FOUND (20191018/psargs-330)
+[    0.168442] No Local Variables are initialized for Method [GCAP]
+[    0.168442] Initialized Arguments for Method [GCAP]:  (1 arguments defined for method invocation)
+[    0.168443]   Arg0:   00000000ad46841f <Obj>           Buffer(12) 00 00 00 00 BF 0B 00 00
+[    0.168446] ACPI Error: Aborting method \_PR.CPU7.GCAP due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.168450] ACPI Error: Aborting method \_PR.CPU7._PDC due to previous error (AE_NOT_FOUND) (20191018/psparse-529)
+[    0.168700] ACPI: Interpreter enabled
+[    0.168718] ACPI: (supports S0 S3 S4 S5)
+[    0.168719] ACPI: Using IOAPIC for interrupt routing
+[    0.168739] PCI: MMCONFIG for domain 0000 [bus 00-ff] at [mem 0xe0000000-0xefffffff] (base 0xe0000000)
+[    0.169221] PCI: MMCONFIG at [mem 0xe0000000-0xefffffff] reserved in ACPI motherboard resources
+[    0.169230] PCI: Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
+[    0.169538] ACPI: Enabled 11 GPEs in block 00 to 7F
+[    0.182825] ACPI: PCI Root Bridge [PCI0] (domain 0000 [bus 00-ff])
+[    0.182829] acpi PNP0A08:00: _OSC: OS assumes control of [PCIeHotplug SHPCHotplug AER PCIeCapability LTR]
+[    0.183167] PCI host bridge to bus 0000:00
+[    0.183169] pci_bus 0000:00: root bus resource [io  0x0000-0x0cf7 window]
+[    0.183169] pci_bus 0000:00: root bus resource [io  0x0d00-0xffff window]
+[    0.183170] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
+[    0.183171] pci_bus 0000:00: root bus resource [mem 0x000c0000-0x000c3fff window]
+[    0.183172] pci_bus 0000:00: root bus resource [mem 0x000c4000-0x000c7fff window]
+[    0.183172] pci_bus 0000:00: root bus resource [mem 0x000c8000-0x000cbfff window]
+[    0.183173] pci_bus 0000:00: root bus resource [mem 0x000cc000-0x000cffff window]
+[    0.183173] pci_bus 0000:00: root bus resource [mem 0x000d0000-0x000d3fff window]
+[    0.183174] pci_bus 0000:00: root bus resource [mem 0x000d4000-0x000d7fff window]
+[    0.183175] pci_bus 0000:00: root bus resource [mem 0x000d8000-0x000dbfff window]
+[    0.183175] pci_bus 0000:00: root bus resource [mem 0x000dc000-0x000dffff window]
+[    0.183176] pci_bus 0000:00: root bus resource [mem 0x000e0000-0x000e3fff window]
+[    0.183177] pci_bus 0000:00: root bus resource [mem 0x000e4000-0x000e7fff window]
+[    0.183177] pci_bus 0000:00: root bus resource [mem 0x000e8000-0x000ebfff window]
+[    0.183178] pci_bus 0000:00: root bus resource [mem 0x000ec000-0x000effff window]
+[    0.183179] pci_bus 0000:00: root bus resource [mem 0x000f0000-0x000fffff window]
+[    0.183179] pci_bus 0000:00: root bus resource [mem 0x80000000-0xfeafffff window]
+[    0.183180] pci_bus 0000:00: root bus resource [bus 00-ff]
+[    0.183187] pci 0000:00:00.0: [8086:1910] type 00 class 0x060000
+[    0.183277] pci 0000:00:01.0: [8086:1901] type 01 class 0x060400
+[    0.183311] pci 0000:00:01.0: PME# supported from D0 D3hot D3cold
+[    0.183379] pci 0000:00:01.1: [8086:1905] type 01 class 0x060400
+[    0.183412] pci 0000:00:01.1: PME# supported from D0 D3hot D3cold
+[    0.183476] pci 0000:00:01.2: [8086:1909] type 01 class 0x060400
+[    0.183508] pci 0000:00:01.2: PME# supported from D0 D3hot D3cold
+[    0.183649] pci 0000:00:14.0: [8086:a12f] type 00 class 0x0c0330
+[    0.183668] pci 0000:00:14.0: reg 0x10: [mem 0x82700000-0x8270ffff 64bit]
+[    0.183721] pci 0000:00:14.0: PME# supported from D3hot D3cold
+[    0.183845] pci 0000:00:15.0: [8086:a160] type 00 class 0x118000
+[    0.183895] pci 0000:00:15.0: reg 0x10: [mem 0x82728000-0x82728fff 64bit]
+[    0.184108] pci 0000:00:16.0: [8086:a13a] type 00 class 0x078000
+[    0.184125] pci 0000:00:16.0: reg 0x10: [mem 0x82729000-0x82729fff 64bit]
+[    0.184176] pci 0000:00:16.0: PME# supported from D3hot
+[    0.184284] pci 0000:00:19.0: [8086:a166] type 00 class 0x118000
+[    0.184330] pci 0000:00:19.0: reg 0x10: [mem 0x8272a000-0x8272afff 64bit]
+[    0.184535] pci 0000:00:1b.0: [8086:a167] type 01 class 0x060400
+[    0.184606] pci 0000:00:1b.0: PME# supported from D0 D3hot D3cold
+[    0.184711] pci 0000:00:1c.0: [8086:a110] type 01 class 0x060400
+[    0.184776] pci 0000:00:1c.0: PME# supported from D0 D3hot D3cold
+[    0.184919] pci 0000:00:1e.0: [8086:a127] type 00 class 0x118000
+[    0.184968] pci 0000:00:1e.0: reg 0x10: [mem 0x8272b000-0x8272bfff 64bit]
+[    0.185206] pci 0000:00:1e.1: [8086:a128] type 00 class 0x118000
+[    0.185254] pci 0000:00:1e.1: reg 0x10: [mem 0x8272c000-0x8272cfff 64bit]
+[    0.185480] pci 0000:00:1e.2: [8086:a129] type 00 class 0x118000
+[    0.185528] pci 0000:00:1e.2: reg 0x10: [mem 0x8272d000-0x8272dfff 64bit]
+[    0.185734] pci 0000:00:1e.3: [8086:a12a] type 00 class 0x118000
+[    0.185781] pci 0000:00:1e.3: reg 0x10: [mem 0x8272e000-0x8272efff 64bit]
+[    0.185981] pci 0000:00:1f.0: [8086:a151] type 00 class 0x060100
+[    0.186131] pci 0000:00:1f.2: [8086:a121] type 00 class 0x058000
+[    0.186142] pci 0000:00:1f.2: reg 0x10: [mem 0x82724000-0x82727fff]
+[    0.186233] pci 0000:00:1f.3: [8086:a170] type 00 class 0x040300
+[    0.186257] pci 0000:00:1f.3: reg 0x10: [mem 0x82720000-0x82723fff 64bit]
+[    0.186285] pci 0000:00:1f.3: reg 0x20: [mem 0x00000000-0x0000ffff 64bit]
+[    0.186326] pci 0000:00:1f.3: PME# supported from D3hot D3cold
+[    0.186404] pci 0000:00:1f.4: [8086:a123] type 00 class 0x0c0500
+[    0.186464] pci 0000:00:1f.4: reg 0x10: [mem 0x8272f000-0x8272f0ff 64bit]
+[    0.186533] pci 0000:00:1f.4: reg 0x20: [io  0x5040-0x505f]
+[    0.186694] pci 0000:01:00.0: [1002:67ef] type 00 class 0x030000
+[    0.186710] pci 0000:01:00.0: reg 0x10: [mem 0xb0000000-0xbfffffff 64bit pref]
+[    0.186718] pci 0000:01:00.0: reg 0x18: [mem 0xc0000000-0xc01fffff 64bit pref]
+[    0.186723] pci 0000:01:00.0: reg 0x20: [io  0x4000-0x40ff]
+[    0.186728] pci 0000:01:00.0: reg 0x24: [mem 0x82600000-0x8263ffff]
+[    0.186734] pci 0000:01:00.0: reg 0x30: [mem 0x82640000-0x8265ffff pref]
+[    0.186744] pci 0000:01:00.0: BAR 0: assigned to efifb
+[    0.186773] pci 0000:01:00.0: supports D1 D2
+[    0.186836] pci 0000:01:00.1: [1002:aae0] type 00 class 0x040300
+[    0.186850] pci 0000:01:00.1: reg 0x10: [mem 0x82660000-0x82663fff 64bit]
+[    0.186901] pci 0000:01:00.1: supports D1 D2
+[    0.186969] pci 0000:00:01.0: PCI bridge to [bus 01]
+[    0.186971] pci 0000:00:01.0:   bridge window [io  0x4000-0x4fff]
+[    0.186972] pci 0000:00:01.0:   bridge window [mem 0x82600000-0x826fffff]
+[    0.186974] pci 0000:00:01.0:   bridge window [mem 0xb0000000-0xc01fffff 64bit pref]
+[    0.187024] pci 0000:04:00.0: [8086:1578] type 01 class 0x060400
+[    0.187060] pci 0000:04:00.0: enabling Extended Tags
+[    0.187111] pci 0000:04:00.0: supports D1 D2
+[    0.187112] pci 0000:04:00.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.197716] pci 0000:00:01.1: PCI bridge to [bus 04-79]
+[    0.197718] pci 0000:00:01.1:   bridge window [io  0x6000-0x9fff]
+[    0.197720] pci 0000:00:01.1:   bridge window [mem 0x82800000-0x909fffff]
+[    0.197722] pci 0000:00:01.1:   bridge window [mem 0xc0200000-0xce1fffff 64bit pref]
+[    0.197815] pci 0000:05:00.0: [8086:15d3] type 01 class 0x060400
+[    0.197856] pci 0000:05:00.0: enabling Extended Tags
+[    0.197916] pci 0000:05:00.0: supports D1 D2
+[    0.197917] pci 0000:05:00.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.198027] pci 0000:05:01.0: [8086:15d3] type 01 class 0x060400
+[    0.198068] pci 0000:05:01.0: enabling Extended Tags
+[    0.198127] pci 0000:05:01.0: supports D1 D2
+[    0.198128] pci 0000:05:01.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.198209] pci 0000:05:02.0: [8086:15d3] type 01 class 0x060400
+[    0.198249] pci 0000:05:02.0: enabling Extended Tags
+[    0.198308] pci 0000:05:02.0: supports D1 D2
+[    0.198308] pci 0000:05:02.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.198416] pci 0000:05:04.0: [8086:15d3] type 01 class 0x060400
+[    0.198457] pci 0000:05:04.0: enabling Extended Tags
+[    0.198516] pci 0000:05:04.0: supports D1 D2
+[    0.198516] pci 0000:05:04.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.198606] pci 0000:04:00.0: PCI bridge to [bus 05-79]
+[    0.198611] pci 0000:04:00.0:   bridge window [io  0x0000-0x0fff]
+[    0.198613] pci 0000:04:00.0:   bridge window [mem 0x82800000-0x909fffff]
+[    0.198617] pci 0000:04:00.0:   bridge window [mem 0xc0200000-0xce1fffff 64bit pref]
+[    0.198671] pci 0000:06:00.0: [8086:15d2] type 00 class 0x088000
+[    0.198694] pci 0000:06:00.0: reg 0x10: [mem 0x82900000-0x8293ffff]
+[    0.198702] pci 0000:06:00.0: reg 0x14: [mem 0x82940000-0x82940fff]
+[    0.198744] pci 0000:06:00.0: enabling Extended Tags
+[    0.198822] pci 0000:06:00.0: supports D1 D2
+[    0.198823] pci 0000:06:00.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.209723] pci 0000:05:00.0: PCI bridge to [bus 06]
+[    0.209727] pci 0000:05:00.0:   bridge window [io  0x0000-0x0fff]
+[    0.209730] pci 0000:05:00.0:   bridge window [mem 0x82900000-0x829fffff]
+[    0.209798] pci 0000:05:01.0: PCI bridge to [bus 08-40]
+[    0.209802] pci 0000:05:01.0:   bridge window [io  0x0000-0x0fff]
+[    0.209805] pci 0000:05:01.0:   bridge window [mem 0x82a00000-0x899fffff]
+[    0.209808] pci 0000:05:01.0:   bridge window [mem 0xc0200000-0xc71fffff 64bit pref]
+[    0.209857] pci 0000:07:00.0: [8086:15d4] type 00 class 0x0c0330
+[    0.209881] pci 0000:07:00.0: reg 0x10: [mem 0x00000000-0x0000ffff]
+[    0.209923] pci 0000:07:00.0: enabling Extended Tags
+[    0.210006] pci 0000:07:00.0: supports D1 D2
+[    0.210007] pci 0000:07:00.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.210067] pci 0000:07:00.0: 8.000 Gb/s available PCIe bandwidth, limited by 2.5 GT/s x4 link at 0000:05:02.0 (capable of 31.504 Gb/s with 8 GT/s x4 link)
+[    0.221725] pci 0000:05:02.0: PCI bridge to [bus 07]
+[    0.221729] pci 0000:05:02.0:   bridge window [io  0x0000-0x0fff]
+[    0.221732] pci 0000:05:02.0:   bridge window [mem 0x82800000-0x828fffff]
+[    0.221799] pci 0000:05:04.0: PCI bridge to [bus 41-79]
+[    0.221803] pci 0000:05:04.0:   bridge window [io  0x0000-0x0fff]
+[    0.221806] pci 0000:05:04.0:   bridge window [mem 0x89a00000-0x909fffff]
+[    0.221809] pci 0000:05:04.0:   bridge window [mem 0xc7200000-0xce1fffff 64bit pref]
+[    0.221881] pci 0000:7a:00.0: [8086:1578] type 01 class 0x060400
+[    0.221918] pci 0000:7a:00.0: enabling Extended Tags
+[    0.221972] pci 0000:7a:00.0: supports D1 D2
+[    0.221972] pci 0000:7a:00.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.233715] pci 0000:00:01.2: PCI bridge to [bus 7a-ef]
+[    0.233716] pci 0000:00:01.2:   bridge window [io  0xa000-0xdfff]
+[    0.233718] pci 0000:00:01.2:   bridge window [mem 0x90a00000-0x9ebfffff]
+[    0.233721] pci 0000:00:01.2:   bridge window [mem 0xce200000-0xdc1fffff 64bit pref]
+[    0.233813] pci 0000:7b:00.0: [8086:15d3] type 01 class 0x060400
+[    0.233854] pci 0000:7b:00.0: enabling Extended Tags
+[    0.233913] pci 0000:7b:00.0: supports D1 D2
+[    0.233914] pci 0000:7b:00.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.234022] pci 0000:7b:01.0: [8086:15d3] type 01 class 0x060400
+[    0.234063] pci 0000:7b:01.0: enabling Extended Tags
+[    0.234122] pci 0000:7b:01.0: supports D1 D2
+[    0.234123] pci 0000:7b:01.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.234200] pci 0000:7b:02.0: [8086:15d3] type 01 class 0x060400
+[    0.234241] pci 0000:7b:02.0: enabling Extended Tags
+[    0.234299] pci 0000:7b:02.0: supports D1 D2
+[    0.234300] pci 0000:7b:02.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.234409] pci 0000:7b:04.0: [8086:15d3] type 01 class 0x060400
+[    0.234450] pci 0000:7b:04.0: enabling Extended Tags
+[    0.234508] pci 0000:7b:04.0: supports D1 D2
+[    0.234509] pci 0000:7b:04.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.234598] pci 0000:7a:00.0: PCI bridge to [bus 7b-ef]
+[    0.234601] pci 0000:7a:00.0:   bridge window [io  0x0000-0x0fff]
+[    0.234604] pci 0000:7a:00.0:   bridge window [mem 0x90a00000-0x9ebfffff]
+[    0.234607] pci 0000:7a:00.0:   bridge window [mem 0xce200000-0xdc1fffff 64bit pref]
+[    0.234660] pci 0000:7c:00.0: [8086:15d2] type 00 class 0x088000
+[    0.234682] pci 0000:7c:00.0: reg 0x10: [mem 0x90b00000-0x90b3ffff]
+[    0.234690] pci 0000:7c:00.0: reg 0x14: [mem 0x90b40000-0x90b40fff]
+[    0.234733] pci 0000:7c:00.0: enabling Extended Tags
+[    0.234810] pci 0000:7c:00.0: supports D1 D2
+[    0.234811] pci 0000:7c:00.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.245723] pci 0000:7b:00.0: PCI bridge to [bus 7c]
+[    0.245727] pci 0000:7b:00.0:   bridge window [io  0x0000-0x0fff]
+[    0.245729] pci 0000:7b:00.0:   bridge window [mem 0x90b00000-0x90bfffff]
+[    0.245795] pci 0000:7b:01.0: PCI bridge to [bus 7e-b6]
+[    0.245799] pci 0000:7b:01.0:   bridge window [io  0x0000-0x0fff]
+[    0.245802] pci 0000:7b:01.0:   bridge window [mem 0x90c00000-0x97bfffff]
+[    0.245805] pci 0000:7b:01.0:   bridge window [mem 0xce200000-0xd51fffff 64bit pref]
+[    0.245858] pci 0000:7d:00.0: [8086:15d4] type 00 class 0x0c0330
+[    0.245881] pci 0000:7d:00.0: reg 0x10: [mem 0x00000000-0x0000ffff]
+[    0.245923] pci 0000:7d:00.0: enabling Extended Tags
+[    0.246006] pci 0000:7d:00.0: supports D1 D2
+[    0.246007] pci 0000:7d:00.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.246066] pci 0000:7d:00.0: 8.000 Gb/s available PCIe bandwidth, limited by 2.5 GT/s x4 link at 0000:7b:02.0 (capable of 31.504 Gb/s with 8 GT/s x4 link)
+[    0.257725] pci 0000:7b:02.0: PCI bridge to [bus 7d]
+[    0.257729] pci 0000:7b:02.0:   bridge window [io  0x0000-0x0fff]
+[    0.257732] pci 0000:7b:02.0:   bridge window [mem 0x90a00000-0x90afffff]
+[    0.257801] pci 0000:7b:04.0: PCI bridge to [bus b7-ef]
+[    0.257805] pci 0000:7b:04.0:   bridge window [io  0x0000-0x0fff]
+[    0.257807] pci 0000:7b:04.0:   bridge window [mem 0x97c00000-0x9ebfffff]
+[    0.257811] pci 0000:7b:04.0:   bridge window [mem 0xd5200000-0xdc1fffff 64bit pref]
+[    0.258041] pci 0000:02:00.0: [144d:a804] type 00 class 0x010802
+[    0.258066] pci 0000:02:00.0: reg 0x10: [mem 0x82500000-0x82503fff 64bit]
+[    0.258073] pci 0000:02:00.0: reg 0x18: [io  0x3000-0x30ff]
+[    0.258462] pci 0000:00:1b.0: PCI bridge to [bus 02]
+[    0.258464] pci 0000:00:1b.0:   bridge window [io  0x3000-0x3fff]
+[    0.258466] pci 0000:00:1b.0:   bridge window [mem 0x82500000-0x825fffff]
+[    0.258549] pci 0000:03:00.0: [14e4:43ba] type 00 class 0x028000
+[    0.258583] pci 0000:03:00.0: reg 0x10: [mem 0x82400000-0x82407fff 64bit]
+[    0.258598] pci 0000:03:00.0: reg 0x18: [mem 0x82000000-0x823fffff 64bit]
+[    0.258716] pci 0000:03:00.0: supports D1 D2
+[    0.258717] pci 0000:03:00.0: PME# supported from D0 D1 D2 D3hot D3cold
+[    0.258901] pci 0000:00:1c.0: PCI bridge to [bus 03]
+[    0.258905] pci 0000:00:1c.0:   bridge window [mem 0x82000000-0x824fffff]
+[    0.260072] ACPI: PCI Interrupt Link [LNKA] (IRQs 1 3 4 5 6 7 10 12 14 15) *0
+[    0.260147] ACPI: PCI Interrupt Link [LNKB] (IRQs 1 3 4 5 6 7 11 12 14 15) *0
+[    0.260220] ACPI: PCI Interrupt Link [LNKC] (IRQs 1 3 4 5 6 7 10 12 14 15) *0
+[    0.260293] ACPI: PCI Interrupt Link [LNKD] (IRQs 1 3 4 5 6 7 11 12 14 15) *0
+[    0.260366] ACPI: PCI Interrupt Link [LNKE] (IRQs 1 3 4 5 6 7 10 12 14 15) *0
+[    0.260438] ACPI: PCI Interrupt Link [LNKF] (IRQs 1 3 4 5 6 7 11 12 14 15) *0
+[    0.260510] ACPI: PCI Interrupt Link [LNKG] (IRQs 1 3 4 5 6 7 10 12 14 15) *0
+[    0.260582] ACPI: PCI Interrupt Link [LNKH] (IRQs 1 3 4 5 6 7 11 12 14 15) *0
+[    0.260791] ACPI: EC: interrupt unblocked
+[    0.260818] ACPI: EC: event unblocked
+[    0.260828] ACPI: \_SB_.PCI0.LPCB.EC__: GPE=0x7, IRQ=-1, EC_CMD/EC_SC=0x66, EC_DATA=0x62
+[    0.260829] ACPI: \_SB_.PCI0.LPCB.EC__: Boot DSDT EC used to handle transactions and events
+[    0.260900] iommu: Default domain type: Translated 
+[    0.260900] pci 0000:01:00.0: vgaarb: VGA device added: decodes=io+mem,owns=none,locks=none
+[    0.260900] pci 0000:01:00.0: vgaarb: bridge control possible
+[    0.260900] pci 0000:01:00.0: vgaarb: setting as boot device
+[    0.260900] vgaarb: loaded
+[    0.260900] SCSI subsystem initialized
+[    0.260900] libata version 3.00 loaded.
+[    0.260900] ACPI: bus type USB registered
+[    0.260900] usbcore: registered new interface driver usbfs
+[    0.260900] usbcore: registered new interface driver hub
+[    0.260900] usbcore: registered new device driver usb
+[    0.260900] pps_core: LinuxPPS API ver. 1 registered
+[    0.260900] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
+[    0.260900] PTP clock support registered
+[    0.260900] EDAC MC: Ver: 3.0.0
+[    0.260900] Registered efivars operations
+[    0.260900] PCI: Using ACPI for IRQ routing
+[    0.265526] PCI: pci_cache_line_size set to 64 bytes
+[    0.266075] e820: reserve RAM buffer [mem 0x00058000-0x0005ffff]
+[    0.266076] e820: reserve RAM buffer [mem 0x0009e000-0x0009ffff]
+[    0.266076] e820: reserve RAM buffer [mem 0x7396a018-0x73ffffff]
+[    0.266077] e820: reserve RAM buffer [mem 0x7397c018-0x73ffffff]
+[    0.266078] e820: reserve RAM buffer [mem 0x74022000-0x77ffffff]
+[    0.266078] e820: reserve RAM buffer [mem 0x74e05000-0x77ffffff]
+[    0.266079] e820: reserve RAM buffer [mem 0x7507e000-0x77ffffff]
+[    0.266080] e820: reserve RAM buffer [mem 0x7ac7f000-0x7bffffff]
+[    0.266081] e820: reserve RAM buffer [mem 0x7b000000-0x7bffffff]
+[    0.266081] e820: reserve RAM buffer [mem 0x47f000000-0x47fffffff]
+[    0.266155] NetLabel: Initializing
+[    0.266155] NetLabel:  domain hash size = 128
+[    0.266156] NetLabel:  protocols = UNLABELED CIPSOv4 CALIPSO
+[    0.266166] NetLabel:  unlabeled traffic allowed by default
+[    0.266244] hpet0: at MMIO 0xfed00000, IRQs 2, 8, 0, 0, 0, 0, 0, 0
+[    0.266247] hpet0: 8 comparators, 64-bit 24.000000 MHz counter
+[    0.269703] clocksource: Switched to clocksource tsc-early
+[    0.280174] *** VALIDATE bpf ***
+[    0.280256] VFS: Disk quotas dquot_6.6.0
+[    0.280268] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+[    0.280291] *** VALIDATE ramfs ***
+[    0.280294] *** VALIDATE hugetlbfs ***
+[    0.280354] AppArmor: AppArmor Filesystem Enabled
+[    0.280377] pnp: PnP ACPI init
+[    0.281140] system 00:00: [io  0xffff] has been reserved
+[    0.281141] system 00:00: [io  0x1800-0x18fe] has been reserved
+[    0.281142] system 00:00: [io  0x0800-0x087f] has been reserved
+[    0.281146] system 00:00: Plug and Play ACPI device, IDs PNP0c02 (active)
+[    0.281161] pnp 00:01: Plug and Play ACPI device, IDs PNP0b00 (active)
+[    0.281213] pnp 00:02: Plug and Play ACPI device, IDs APP000b (active)
+[    0.281413] system 00:03: [mem 0xfed10000-0xfed17fff] has been reserved
+[    0.281414] system 00:03: [mem 0xfed18000-0xfed18fff] has been reserved
+[    0.281415] system 00:03: [mem 0xfed19000-0xfed19fff] has been reserved
+[    0.281416] system 00:03: [mem 0xe0000000-0xefffffff] could not be reserved
+[    0.281417] system 00:03: [mem 0xfed20000-0xfed3ffff] has been reserved
+[    0.281418] system 00:03: [mem 0xfed90000-0xfed93fff] could not be reserved
+[    0.281419] system 00:03: [mem 0xfed45000-0xfed8ffff] has been reserved
+[    0.281420] system 00:03: [mem 0xff000000-0xffffffff] could not be reserved
+[    0.281421] system 00:03: [mem 0xfee00000-0xfeefffff] has been reserved
+[    0.281422] system 00:03: [mem 0xfd000000-0xfdffffff] has been reserved
+[    0.281423] system 00:03: [mem 0xfe000000-0xfe00ffff] has been reserved
+[    0.281424] system 00:03: [mem 0xfe010000-0xfe010fff] has been reserved
+[    0.281425] system 00:03: [mem 0xfe020000-0xfe035fff] has been reserved
+[    0.281427] system 00:03: [mem 0xfe036000-0xfe03bfff] has been reserved
+[    0.281428] system 00:03: [mem 0xfe03c000-0xfe03cfff] has been reserved
+[    0.281429] system 00:03: [mem 0xfe03d000-0xfe0bffff] has been reserved
+[    0.281430] system 00:03: [mem 0xfe0c0000-0xfe0fffff] has been reserved
+[    0.281431] system 00:03: [mem 0xfe100000-0xfe1fffff] has been reserved
+[    0.281432] system 00:03: [mem 0xfe200000-0xfe3fffff] has been reserved
+[    0.281433] system 00:03: [mem 0xfe400000-0xfe40ffff] has been reserved
+[    0.281434] system 00:03: [mem 0xfe410000-0xfe5fffff] has been reserved
+[    0.281435] system 00:03: [mem 0xfe600000-0xfe7fffff] has been reserved
+[    0.281438] system 00:03: Plug and Play ACPI device, IDs PNP0c02 (active)
+[    0.281481] system 00:04: [mem 0x20000000-0x201fffff] could not be reserved
+[    0.281482] system 00:04: [mem 0x40000000-0x401fffff] could not be reserved
+[    0.281484] system 00:04: Plug and Play ACPI device, IDs PNP0c01 (active)
+[    0.281683] pnp: PnP ACPI: found 5 devices
+[    0.282617] apple-properties: device path parse error -19 at 0x14:
+[    0.282622] apple-properties: 00000000: a6 01 00 00 04 00 00 00 02 01 0c 00 d0 41 03 0a  .............A..
+[    0.282625] apple-properties: 00000010: 00 00 00 00 01 01 06 00 00 02 7f ff 04 00 1e 00  ................
+[    0.282627] apple-properties: 00000020: 00 00 73 00 61 00 76 00 65 00 64 00 2d 00 63 00  ..s.a.v.e.d.-.c.
+[    0.282629] apple-properties: 00000030: 6f 00 6e 00 66 00 69 00 67 00 00 00 e2 00 00 00  o.n.f.i.g.......
+[    0.282632] apple-properties: 00000040: 47 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  G...............
+[    0.282634] apple-properties: 00000050: 00 00 03 00 06 00 1b 19 00 6c 05 00 00 00 00 00  .........l......
+[    0.282636] apple-properties: 00000060: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+[    0.282638] apple-properties: 00000070: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+[    0.282640] apple-properties: 00000080: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+[    0.282642] apple-properties: 00000090: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+[    0.282644] apple-properties: 000000a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+[    0.282646] apple-properties: 000000b0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+[    0.282648] apple-properties: 000000c0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+[    0.282650] apple-properties: 000000d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+[    0.282653] apple-properties: 000000e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+[    0.282655] apple-properties: 000000f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+[    0.282657] apple-properties: 00000100: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+[    0.282659] apple-properties: 00000110: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 2c 00  ..............,.
+[    0.282661] apple-properties: 00000120: 00 00 41 00 41 00 50 00 4c 00 2c 00 69 00 67 00  ..A.A.P.L.,.i.g.
+[    0.282663] apple-properties: 00000130: 2d 00 70 00 6c 00 61 00 74 00 66 00 6f 00 72 00  -.p.l.a.t.f.o.r.
+[    0.282666] apple-properties: 00000140: 6d 00 2d 00 69 00 64 00 00 00 08 00 00 00 06 00  m.-.i.d.........
+[    0.282668] apple-properties: 00000150: 1b 19 20 00 00 00 41 00 41 00 50 00 4c 00 2c 00  .. ...A.A.P.L.,.
+[    0.282670] apple-properties: 00000160: 47 00 66 00 78 00 59 00 54 00 69 00 6c 00 65 00  G.f.x.Y.T.i.l.e.
+[    0.282672] apple-properties: 00000170: 00 00 08 00 00 00 01 00 00 00 24 00 00 00 67 00  ..........$...g.
+[    0.282674] apple-properties: 00000180: 72 00 61 00 70 00 68 00 69 00 63 00 2d 00 6f 00  r.a.p.h.i.c.-.o.
+[    0.282676] apple-properties: 00000190: 70 00 74 00 69 00 6f 00 6e 00 73 00 00 00 08 00  p.t.i.o.n.s.....
+[    0.282678] apple-properties: 000001a0: 00 00 0c 00 00 00                                ......
+[    0.282692] pci 0000:01:00.0: assigning 67 device properties
+[    0.282720] pci 0000:06:00.0: assigning 8 device properties
+[    0.282727] pci 0000:7c:00.0: assigning 8 device properties
+[    0.282734] pci 0000:00:1f.3: assigning 4 device properties
+[    0.287224] clocksource: acpi_pm: mask: 0xffffff max_cycles: 0xffffff, max_idle_ns: 2085701024 ns
+[    0.287253] pci 0000:05:01.0: bridge window [io  0x1000-0x0fff] to [bus 08-40] add_size 1000
+[    0.287254] pci 0000:05:02.0: bridge window [io  0x1000-0x0fff] to [bus 07] add_size 1000
+[    0.287256] pci 0000:05:02.0: bridge window [mem 0x00100000-0x000fffff 64bit pref] to [bus 07] add_size 200000 add_align 100000
+[    0.287257] pci 0000:05:04.0: bridge window [io  0x1000-0x0fff] to [bus 41-79] add_size 1000
+[    0.287259] pci 0000:04:00.0: bridge window [io  0x1000-0x0fff] to [bus 05-79] add_size 3000
+[    0.287260] pci 0000:7b:01.0: bridge window [io  0x1000-0x0fff] to [bus 7e-b6] add_size 1000
+[    0.287261] pci 0000:7b:02.0: bridge window [io  0x1000-0x0fff] to [bus 7d] add_size 1000
+[    0.287262] pci 0000:7b:02.0: bridge window [mem 0x00100000-0x000fffff 64bit pref] to [bus 7d] add_size 200000 add_align 100000
+[    0.287263] pci 0000:7b:04.0: bridge window [io  0x1000-0x0fff] to [bus b7-ef] add_size 1000
+[    0.287264] pci 0000:7a:00.0: bridge window [io  0x1000-0x0fff] to [bus 7b-ef] add_size 3000
+[    0.287276] pci 0000:00:1f.3: BAR 4: assigned [mem 0x80000000-0x8000ffff 64bit]
+[    0.287297] pci 0000:00:01.0: PCI bridge to [bus 01]
+[    0.287298] pci 0000:00:01.0:   bridge window [io  0x4000-0x4fff]
+[    0.287300] pci 0000:00:01.0:   bridge window [mem 0x82600000-0x826fffff]
+[    0.287302] pci 0000:00:01.0:   bridge window [mem 0xb0000000-0xc01fffff 64bit pref]
+[    0.287305] pci 0000:04:00.0: BAR 13: assigned [io  0x6000-0x8fff]
+[    0.287309] pci 0000:05:02.0: BAR 15: no space for [mem size 0x00200000 64bit pref]
+[    0.287310] pci 0000:05:02.0: BAR 15: failed to assign [mem size 0x00200000 64bit pref]
+[    0.287311] pci 0000:05:01.0: BAR 13: assigned [io  0x6000-0x6fff]
+[    0.287312] pci 0000:05:02.0: BAR 13: assigned [io  0x7000-0x7fff]
+[    0.287313] pci 0000:05:04.0: BAR 13: assigned [io  0x8000-0x8fff]
+[    0.287315] pci 0000:05:02.0: BAR 15: no space for [mem size 0x00200000 64bit pref]
+[    0.287316] pci 0000:05:02.0: BAR 15: failed to assign [mem size 0x00200000 64bit pref]
+[    0.287317] pci 0000:05:00.0: PCI bridge to [bus 06]
+[    0.287320] pci 0000:05:00.0:   bridge window [mem 0x82900000-0x829fffff]
+[    0.287325] pci 0000:05:01.0: PCI bridge to [bus 08-40]
+[    0.287327] pci 0000:05:01.0:   bridge window [io  0x6000-0x6fff]
+[    0.287330] pci 0000:05:01.0:   bridge window [mem 0x82a00000-0x899fffff]
+[    0.287332] pci 0000:05:01.0:   bridge window [mem 0xc0200000-0xc71fffff 64bit pref]
+[    0.287337] pci 0000:07:00.0: BAR 0: assigned [mem 0x82800000-0x8280ffff]
+[    0.287340] pci 0000:05:02.0: PCI bridge to [bus 07]
+[    0.287342] pci 0000:05:02.0:   bridge window [io  0x7000-0x7fff]
+[    0.287345] pci 0000:05:02.0:   bridge window [mem 0x82800000-0x828fffff]
+[    0.287350] pci 0000:05:04.0: PCI bridge to [bus 41-79]
+[    0.287352] pci 0000:05:04.0:   bridge window [io  0x8000-0x8fff]
+[    0.287355] pci 0000:05:04.0:   bridge window [mem 0x89a00000-0x909fffff]
+[    0.287357] pci 0000:05:04.0:   bridge window [mem 0xc7200000-0xce1fffff 64bit pref]
+[    0.287361] pci 0000:04:00.0: PCI bridge to [bus 05-79]
+[    0.287362] pci 0000:04:00.0:   bridge window [io  0x6000-0x8fff]
+[    0.287365] pci 0000:04:00.0:   bridge window [mem 0x82800000-0x909fffff]
+[    0.287368] pci 0000:04:00.0:   bridge window [mem 0xc0200000-0xce1fffff 64bit pref]
+[    0.287371] pci 0000:00:01.1: PCI bridge to [bus 04-79]
+[    0.287372] pci 0000:00:01.1:   bridge window [io  0x6000-0x9fff]
+[    0.287374] pci 0000:00:01.1:   bridge window [mem 0x82800000-0x909fffff]
+[    0.287376] pci 0000:00:01.1:   bridge window [mem 0xc0200000-0xce1fffff 64bit pref]
+[    0.287379] pci 0000:7a:00.0: BAR 13: assigned [io  0xa000-0xcfff]
+[    0.287381] pci 0000:7b:02.0: BAR 15: no space for [mem size 0x00200000 64bit pref]
+[    0.287382] pci 0000:7b:02.0: BAR 15: failed to assign [mem size 0x00200000 64bit pref]
+[    0.287383] pci 0000:7b:01.0: BAR 13: assigned [io  0xa000-0xafff]
+[    0.287384] pci 0000:7b:02.0: BAR 13: assigned [io  0xb000-0xbfff]
+[    0.287384] pci 0000:7b:04.0: BAR 13: assigned [io  0xc000-0xcfff]
+[    0.287386] pci 0000:7b:02.0: BAR 15: no space for [mem size 0x00200000 64bit pref]
+[    0.287387] pci 0000:7b:02.0: BAR 15: failed to assign [mem size 0x00200000 64bit pref]
+[    0.287388] pci 0000:7b:00.0: PCI bridge to [bus 7c]
+[    0.287391] pci 0000:7b:00.0:   bridge window [mem 0x90b00000-0x90bfffff]
+[    0.287397] pci 0000:7b:01.0: PCI bridge to [bus 7e-b6]
+[    0.287398] pci 0000:7b:01.0:   bridge window [io  0xa000-0xafff]
+[    0.287401] pci 0000:7b:01.0:   bridge window [mem 0x90c00000-0x97bfffff]
+[    0.287404] pci 0000:7b:01.0:   bridge window [mem 0xce200000-0xd51fffff 64bit pref]
+[    0.287408] pci 0000:7d:00.0: BAR 0: assigned [mem 0x90a00000-0x90a0ffff]
+[    0.287411] pci 0000:7b:02.0: PCI bridge to [bus 7d]
+[    0.287412] pci 0000:7b:02.0:   bridge window [io  0xb000-0xbfff]
+[    0.287415] pci 0000:7b:02.0:   bridge window [mem 0x90a00000-0x90afffff]
+[    0.287421] pci 0000:7b:04.0: PCI bridge to [bus b7-ef]
+[    0.287422] pci 0000:7b:04.0:   bridge window [io  0xc000-0xcfff]
+[    0.287425] pci 0000:7b:04.0:   bridge window [mem 0x97c00000-0x9ebfffff]
+[    0.287427] pci 0000:7b:04.0:   bridge window [mem 0xd5200000-0xdc1fffff 64bit pref]
+[    0.287431] pci 0000:7a:00.0: PCI bridge to [bus 7b-ef]
+[    0.287432] pci 0000:7a:00.0:   bridge window [io  0xa000-0xcfff]
+[    0.287435] pci 0000:7a:00.0:   bridge window [mem 0x90a00000-0x9ebfffff]
+[    0.287438] pci 0000:7a:00.0:   bridge window [mem 0xce200000-0xdc1fffff 64bit pref]
+[    0.287441] pci 0000:00:01.2: PCI bridge to [bus 7a-ef]
+[    0.287442] pci 0000:00:01.2:   bridge window [io  0xa000-0xdfff]
+[    0.287444] pci 0000:00:01.2:   bridge window [mem 0x90a00000-0x9ebfffff]
+[    0.287446] pci 0000:00:01.2:   bridge window [mem 0xce200000-0xdc1fffff 64bit pref]
+[    0.287448] pci 0000:00:1b.0: PCI bridge to [bus 02]
+[    0.287461] pci 0000:00:1b.0:   bridge window [io  0x3000-0x3fff]
+[    0.287464] pci 0000:00:1b.0:   bridge window [mem 0x82500000-0x825fffff]
+[    0.287469] pci 0000:00:1c.0: PCI bridge to [bus 03]
+[    0.287474] pci 0000:00:1c.0:   bridge window [mem 0x82000000-0x824fffff]
+[    0.287480] pci_bus 0000:00: resource 4 [io  0x0000-0x0cf7 window]
+[    0.287481] pci_bus 0000:00: resource 5 [io  0x0d00-0xffff window]
+[    0.287482] pci_bus 0000:00: resource 6 [mem 0x000a0000-0x000bffff window]
+[    0.287482] pci_bus 0000:00: resource 7 [mem 0x000c0000-0x000c3fff window]
+[    0.287483] pci_bus 0000:00: resource 8 [mem 0x000c4000-0x000c7fff window]
+[    0.287484] pci_bus 0000:00: resource 9 [mem 0x000c8000-0x000cbfff window]
+[    0.287485] pci_bus 0000:00: resource 10 [mem 0x000cc000-0x000cffff window]
+[    0.287486] pci_bus 0000:00: resource 11 [mem 0x000d0000-0x000d3fff window]
+[    0.287486] pci_bus 0000:00: resource 12 [mem 0x000d4000-0x000d7fff window]
+[    0.287487] pci_bus 0000:00: resource 13 [mem 0x000d8000-0x000dbfff window]
+[    0.287488] pci_bus 0000:00: resource 14 [mem 0x000dc000-0x000dffff window]
+[    0.287489] pci_bus 0000:00: resource 15 [mem 0x000e0000-0x000e3fff window]
+[    0.287490] pci_bus 0000:00: resource 16 [mem 0x000e4000-0x000e7fff window]
+[    0.287490] pci_bus 0000:00: resource 17 [mem 0x000e8000-0x000ebfff window]
+[    0.287491] pci_bus 0000:00: resource 18 [mem 0x000ec000-0x000effff window]
+[    0.287492] pci_bus 0000:00: resource 19 [mem 0x000f0000-0x000fffff window]
+[    0.287493] pci_bus 0000:00: resource 20 [mem 0x80000000-0xfeafffff window]
+[    0.287494] pci_bus 0000:01: resource 0 [io  0x4000-0x4fff]
+[    0.287495] pci_bus 0000:01: resource 1 [mem 0x82600000-0x826fffff]
+[    0.287495] pci_bus 0000:01: resource 2 [mem 0xb0000000-0xc01fffff 64bit pref]
+[    0.287496] pci_bus 0000:04: resource 0 [io  0x6000-0x9fff]
+[    0.287497] pci_bus 0000:04: resource 1 [mem 0x82800000-0x909fffff]
+[    0.287498] pci_bus 0000:04: resource 2 [mem 0xc0200000-0xce1fffff 64bit pref]
+[    0.287499] pci_bus 0000:05: resource 0 [io  0x6000-0x8fff]
+[    0.287500] pci_bus 0000:05: resource 1 [mem 0x82800000-0x909fffff]
+[    0.287500] pci_bus 0000:05: resource 2 [mem 0xc0200000-0xce1fffff 64bit pref]
+[    0.287501] pci_bus 0000:06: resource 1 [mem 0x82900000-0x829fffff]
+[    0.287502] pci_bus 0000:08: resource 0 [io  0x6000-0x6fff]
+[    0.287503] pci_bus 0000:08: resource 1 [mem 0x82a00000-0x899fffff]
+[    0.287504] pci_bus 0000:08: resource 2 [mem 0xc0200000-0xc71fffff 64bit pref]
+[    0.287504] pci_bus 0000:07: resource 0 [io  0x7000-0x7fff]
+[    0.287505] pci_bus 0000:07: resource 1 [mem 0x82800000-0x828fffff]
+[    0.287506] pci_bus 0000:41: resource 0 [io  0x8000-0x8fff]
+[    0.287507] pci_bus 0000:41: resource 1 [mem 0x89a00000-0x909fffff]
+[    0.287507] pci_bus 0000:41: resource 2 [mem 0xc7200000-0xce1fffff 64bit pref]
+[    0.287508] pci_bus 0000:7a: resource 0 [io  0xa000-0xdfff]
+[    0.287509] pci_bus 0000:7a: resource 1 [mem 0x90a00000-0x9ebfffff]
+[    0.287510] pci_bus 0000:7a: resource 2 [mem 0xce200000-0xdc1fffff 64bit pref]
+[    0.287511] pci_bus 0000:7b: resource 0 [io  0xa000-0xcfff]
+[    0.287511] pci_bus 0000:7b: resource 1 [mem 0x90a00000-0x9ebfffff]
+[    0.287512] pci_bus 0000:7b: resource 2 [mem 0xce200000-0xdc1fffff 64bit pref]
+[    0.287513] pci_bus 0000:7c: resource 1 [mem 0x90b00000-0x90bfffff]
+[    0.287514] pci_bus 0000:7e: resource 0 [io  0xa000-0xafff]
+[    0.287514] pci_bus 0000:7e: resource 1 [mem 0x90c00000-0x97bfffff]
+[    0.287515] pci_bus 0000:7e: resource 2 [mem 0xce200000-0xd51fffff 64bit pref]
+[    0.287516] pci_bus 0000:7d: resource 0 [io  0xb000-0xbfff]
+[    0.287517] pci_bus 0000:7d: resource 1 [mem 0x90a00000-0x90afffff]
+[    0.287518] pci_bus 0000:b7: resource 0 [io  0xc000-0xcfff]
+[    0.287518] pci_bus 0000:b7: resource 1 [mem 0x97c00000-0x9ebfffff]
+[    0.287519] pci_bus 0000:b7: resource 2 [mem 0xd5200000-0xdc1fffff 64bit pref]
+[    0.287520] pci_bus 0000:02: resource 0 [io  0x3000-0x3fff]
+[    0.287521] pci_bus 0000:02: resource 1 [mem 0x82500000-0x825fffff]
+[    0.287522] pci_bus 0000:03: resource 1 [mem 0x82000000-0x824fffff]
+[    0.287699] NET: Registered protocol family 2
+[    0.287825] tcp_listen_portaddr_hash hash table entries: 8192 (order: 5, 131072 bytes, linear)
+[    0.287893] TCP established hash table entries: 131072 (order: 8, 1048576 bytes, linear)
+[    0.288042] TCP bind hash table entries: 65536 (order: 8, 1048576 bytes, linear)
+[    0.288112] TCP: Hash tables configured (established 131072 bind 65536)
+[    0.288152] UDP hash table entries: 8192 (order: 6, 262144 bytes, linear)
+[    0.288190] UDP-Lite hash table entries: 8192 (order: 6, 262144 bytes, linear)
+[    0.288242] NET: Registered protocol family 1
+[    0.288247] NET: Registered protocol family 44
+[    0.288592] pci 0000:01:00.1: D0 power state depends on 0000:01:00.0
+[    0.288790] pci 0000:07:00.0: enabling device (0000 -> 0002)
+[    0.289027] pci 0000:7d:00.0: enabling device (0000 -> 0002)
+[    0.289300] PCI: CLS 256 bytes, default 64
+[    0.289327] Trying to unpack rootfs image as initramfs...
+[    1.092188] Freeing initrd memory: 65096K
+[    1.092227] DMAR: ACPI device "device:91" under DMAR at fed91000 as 00:15.0
+[    1.092229] DMAR: ACPI device "device:92" under DMAR at fed91000 as 00:1e.2
+[    1.092231] DMAR: ACPI device "device:93" under DMAR at fed91000 as 00:1e.3
+[    1.092232] DMAR: Failed to find handle for ACPI object \_SB.PCI0.UA00
+[    1.092236] DMAR: Failed to find handle for ACPI object \_SB.PCI0.UA01
+[    1.092238] DMAR: Failed to find handle for ACPI object \_SB.PCI0.UA02
+[    1.117747] PCI-DMA: Using software bounce buffering for IO (SWIOTLB)
+[    1.117748] software IO TLB: mapped [mem 0x6c75d000-0x7075d000] (64MB)
+[    1.118005] check: Scanning for low memory corruption every 60 seconds
+[    1.119307] Initialise system trusted keyrings
+[    1.119314] Key type blacklist registered
+[    1.119336] workingset: timestamp_bits=36 max_order=22 bucket_order=0
+[    1.120326] zbud: loaded
+[    1.120542] squashfs: version 4.0 (2009/01/31) Phillip Lougher
+[    1.120654] fuse: init (API version 7.31)
+[    1.120666] *** VALIDATE fuse ***
+[    1.120667] *** VALIDATE fuse ***
+[    1.120767] Platform Keyring initialized
+[    1.124322] Key type asymmetric registered
+[    1.124323] Asymmetric key parser 'x509' registered
+[    1.124328] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 244)
+[    1.124359] io scheduler mq-deadline registered
+[    1.125315] pcieport 0000:05:01.0: pciehp: Slot #1 AttnBtn- PwrCtrl- MRL- AttnInd- PwrInd- HotPlug+ Surprise+ Interlock- NoCompl+ LLActRep+
+[    1.125461] pcieport 0000:05:02.0: pciehp: Slot #0 AttnBtn- PwrCtrl- MRL- AttnInd- PwrInd- HotPlug+ Surprise+ Interlock- NoCompl+ LLActRep+
+[    1.125627] pcieport 0000:05:04.0: pciehp: Slot #4 AttnBtn- PwrCtrl- MRL- AttnInd- PwrInd- HotPlug+ Surprise+ Interlock- NoCompl+ LLActRep+
+[    1.126013] pcieport 0000:7b:01.0: pciehp: Slot #1 AttnBtn- PwrCtrl- MRL- AttnInd- PwrInd- HotPlug+ Surprise+ Interlock- NoCompl+ LLActRep+
+[    1.126145] pcieport 0000:7b:02.0: pciehp: Slot #0 AttnBtn- PwrCtrl- MRL- AttnInd- PwrInd- HotPlug+ Surprise+ Interlock- NoCompl+ LLActRep+
+[    1.126310] pcieport 0000:7b:04.0: pciehp: Slot #4 AttnBtn- PwrCtrl- MRL- AttnInd- PwrInd- HotPlug+ Surprise+ Interlock- NoCompl+ LLActRep+
+[    1.126426] shpchp: Standard Hot Plug PCI Controller Driver version: 0.4
+[    1.126472] efifb: probing for efifb
+[    1.126502] efifb: No BGRT, not showing boot graphics
+[    1.126503] efifb: framebuffer at 0xb0300000, using 29400k, total 29400k
+[    1.126504] efifb: mode is 3360x2100x32, linelength=14336, pages=1
+[    1.126505] efifb: scrolling: redraw
+[    1.126506] efifb: Truecolor: size=8:8:8:8, shift=24:16:8:0
+[    1.126570] Console: switching to colour frame buffer device 210x65
+[    1.136008] fb0: EFI VGA frame buffer device
+[    1.136013] intel_idle: MWAIT substates: 0x11142120
+[    1.136014] intel_idle: v0.4.1 model 0x5E
+[    1.136017] intel_idle: state C8 is disabled
+[    1.136017] intel_idle: state C9 is disabled
+[    1.136256] intel_idle: lapic_timer_reliable_states 0xffffffff
+[    1.136393] ACPI: AC Adapter [ADP1] (on-line)
+[    1.136451] input: Lid Switch as /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0C0D:00/input/input0
+[    1.136472] ACPI: Lid Switch [LID0]
+[    1.136489] input: Power Button as /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0C0C:00/input/input1
+[    1.136498] ACPI: Power Button [PWRB]
+[    1.136514] input: Sleep Button as /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0C0E:00/input/input2
+[    1.136523] ACPI: Sleep Button [SLPB]
+[    1.136538] input: Power Button as /devices/LNXSYSTM:00/LNXPWRBN:00/input/input3
+[    1.136551] ACPI: Power Button [PWRF]
+[    1.137478] Serial: 8250/16550 driver, 32 ports, IRQ sharing enabled
+[    1.138601] Linux agpgart interface v0.103
+[    1.140220] loop: module loaded
+[    1.140341] libphy: Fixed MDIO Bus: probed
+[    1.140341] tun: Universal TUN/TAP device driver, 1.6
+[    1.140355] PPP generic driver version 2.4.2
+[    1.140384] VFIO - User Level meta-driver version: 0.3
+[    1.140461] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+[    1.140465] ehci-pci: EHCI PCI platform driver
+[    1.140472] ehci-platform: EHCI generic platform driver
+[    1.140477] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
+[    1.140478] ohci-pci: OHCI PCI platform driver
+[    1.140497] ohci-platform: OHCI generic platform driver
+[    1.140501] uhci_hcd: USB Universal Host Controller Interface driver
+[    1.140638] xhci_hcd 0000:00:14.0: xHCI Host Controller
+[    1.140641] xhci_hcd 0000:00:14.0: new USB bus registered, assigned bus number 1
+[    1.141770] xhci_hcd 0000:00:14.0: hcc params 0x200077c1 hci version 0x100 quirks 0x0000000001109810
+[    1.141805] xhci_hcd 0000:00:14.0: cache line size of 256 is not supported
+[    1.141952] usb usb1: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 5.05
+[    1.141952] usb usb1: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+[    1.141953] usb usb1: Product: xHCI Host Controller
+[    1.141954] usb usb1: Manufacturer: Linux 5.5.11-050511-generic xhci-hcd
+[    1.141954] usb usb1: SerialNumber: 0000:00:14.0
+[    1.142059] hub 1-0:1.0: USB hub found
+[    1.142082] hub 1-0:1.0: 16 ports detected
+[    1.142423] xhci_hcd 0000:00:14.0: xHCI Host Controller
+[    1.142425] xhci_hcd 0000:00:14.0: new USB bus registered, assigned bus number 2
+[    1.142426] xhci_hcd 0000:00:14.0: Host supports USB 3.0 SuperSpeed
+[    1.142447] usb usb2: New USB device found, idVendor=1d6b, idProduct=0003, bcdDevice= 5.05
+[    1.142448] usb usb2: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+[    1.142449] usb usb2: Product: xHCI Host Controller
+[    1.142449] usb usb2: Manufacturer: Linux 5.5.11-050511-generic xhci-hcd
+[    1.142450] usb usb2: SerialNumber: 0000:00:14.0
+[    1.142555] hub 2-0:1.0: USB hub found
+[    1.142573] hub 2-0:1.0: 8 ports detected
+[    1.142799] xhci_hcd 0000:07:00.0: xHCI Host Controller
+[    1.142801] xhci_hcd 0000:07:00.0: new USB bus registered, assigned bus number 3
+[    1.143875] xhci_hcd 0000:07:00.0: hcc params 0x200077c1 hci version 0x110 quirks 0x0000000200009810
+[    1.144004] usb usb3: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 5.05
+[    1.144005] usb usb3: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+[    1.144006] usb usb3: Product: xHCI Host Controller
+[    1.144006] usb usb3: Manufacturer: Linux 5.5.11-050511-generic xhci-hcd
+[    1.144007] usb usb3: SerialNumber: 0000:07:00.0
+[    1.144100] hub 3-0:1.0: USB hub found
+[    1.144105] hub 3-0:1.0: 2 ports detected
+[    1.144217] xhci_hcd 0000:07:00.0: xHCI Host Controller
+[    1.144218] xhci_hcd 0000:07:00.0: new USB bus registered, assigned bus number 4
+[    1.144220] xhci_hcd 0000:07:00.0: Host supports USB 3.1 Enhanced SuperSpeed
+[    1.144238] usb usb4: New USB device found, idVendor=1d6b, idProduct=0003, bcdDevice= 5.05
+[    1.144239] usb usb4: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+[    1.144239] usb usb4: Product: xHCI Host Controller
+[    1.144240] usb usb4: Manufacturer: Linux 5.5.11-050511-generic xhci-hcd
+[    1.144240] usb usb4: SerialNumber: 0000:07:00.0
+[    1.144336] hub 4-0:1.0: USB hub found
+[    1.144341] hub 4-0:1.0: 2 ports detected
+[    1.144465] xhci_hcd 0000:7d:00.0: xHCI Host Controller
+[    1.144467] xhci_hcd 0000:7d:00.0: new USB bus registered, assigned bus number 5
+[    1.145538] xhci_hcd 0000:7d:00.0: hcc params 0x200077c1 hci version 0x110 quirks 0x0000000200009810
+[    1.145666] usb usb5: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 5.05
+[    1.145666] usb usb5: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+[    1.145667] usb usb5: Product: xHCI Host Controller
+[    1.145667] usb usb5: Manufacturer: Linux 5.5.11-050511-generic xhci-hcd
+[    1.145668] usb usb5: SerialNumber: 0000:7d:00.0
+[    1.145791] hub 5-0:1.0: USB hub found
+[    1.145796] hub 5-0:1.0: 2 ports detected
+[    1.145910] xhci_hcd 0000:7d:00.0: xHCI Host Controller
+[    1.145911] xhci_hcd 0000:7d:00.0: new USB bus registered, assigned bus number 6
+[    1.145912] xhci_hcd 0000:7d:00.0: Host supports USB 3.1 Enhanced SuperSpeed
+[    1.145930] usb usb6: New USB device found, idVendor=1d6b, idProduct=0003, bcdDevice= 5.05
+[    1.145931] usb usb6: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+[    1.145932] usb usb6: Product: xHCI Host Controller
+[    1.145932] usb usb6: Manufacturer: Linux 5.5.11-050511-generic xhci-hcd
+[    1.145933] usb usb6: SerialNumber: 0000:7d:00.0
+[    1.146027] hub 6-0:1.0: USB hub found
+[    1.146032] hub 6-0:1.0: 2 ports detected
+[    1.146117] i8042: PNP: No PS/2 controller found.
+[    1.146257] mousedev: PS/2 mouse device common for all mice
+[    1.146528] rtc_cmos 00:01: RTC can wake from S4
+[    1.146988] rtc_cmos 00:01: registered as rtc0
+[    1.146997] rtc_cmos 00:01: alarms up to one month, y3k, 242 bytes nvram, hpet irqs
+[    1.147000] i2c /dev entries driver
+[    1.147027] device-mapper: uevent: version 1.0.3
+[    1.147057] device-mapper: ioctl: 4.41.0-ioctl (2019-09-16) initialised: dm-devel@redhat.com
+[    1.147116] platform eisa.0: Probing EISA bus 0
+[    1.147117] platform eisa.0: EISA: Cannot allocate resource for mainboard
+[    1.147118] platform eisa.0: Cannot allocate resource for EISA slot 1
+[    1.147118] platform eisa.0: Cannot allocate resource for EISA slot 2
+[    1.147119] platform eisa.0: Cannot allocate resource for EISA slot 3
+[    1.147119] platform eisa.0: Cannot allocate resource for EISA slot 4
+[    1.147120] platform eisa.0: Cannot allocate resource for EISA slot 5
+[    1.147121] platform eisa.0: Cannot allocate resource for EISA slot 6
+[    1.147121] platform eisa.0: Cannot allocate resource for EISA slot 7
+[    1.147122] platform eisa.0: Cannot allocate resource for EISA slot 8
+[    1.147122] platform eisa.0: EISA: Detected 0 cards
+[    1.147124] intel_pstate: Intel P-state driver initializing
+[    1.147672] intel_pstate: HWP enabled
+[    1.147918] ledtrig-cpu: registered to indicate activity on CPUs
+[    1.147920] EFI Variables Facility v0.08 2004-May-17
+[    1.442969] intel_pmc_core intel_pmc_core.0:  initialized
+[    1.442991] drop_monitor: Initializing network drop monitor service
+[    1.443153] NET: Registered protocol family 10
+[    1.449282] Segment Routing with IPv6
+[    1.449297] NET: Registered protocol family 17
+[    1.449486] Key type dns_resolver registered
+[    1.450180] RAS: Correctable Errors collector initialized.
+[    1.450226] microcode: sig=0x506e3, pf=0x20, revision=0xd6
+[    1.450467] microcode: Microcode Update Driver: v2.2.
+[    1.450470] IPI shorthand broadcast: enabled
+[    1.450474] sched_clock: Marking stable (1454089326, -3624336)->(1456351008, -5886018)
+[    1.450733] registered taskstats version 1
+[    1.450740] Loading compiled-in X.509 certificates
+[    1.452146] Loaded X.509 cert 'Build time autogenerated kernel key: 4d91a07fa2760a9fbef14f62f2d5d74389c83a99'
+[    1.452168] zswap: loaded using pool lzo/zbud
+[    1.452354] Key type ._fscrypt registered
+[    1.452354] Key type .fscrypt registered
+[    1.457010] Key type big_key registered
+[    1.459748] Key type encrypted registered
+[    1.459750] AppArmor: AppArmor sha1 policy hashing enabled
+[    1.473774] usb 1-3: new high-speed USB device number 2 using xhci_hcd
+[    1.486356] ima: No TPM chip found, activating TPM-bypass!
+[    1.486362] ima: Allocated hash algorithm: sha1
+[    1.486366] ima: No architecture policies found
+[    1.486372] evm: Initialising EVM extended attributes:
+[    1.486372] evm: security.selinux
+[    1.486372] evm: security.SMACK64
+[    1.486373] evm: security.SMACK64EXEC
+[    1.486373] evm: security.SMACK64TRANSMUTE
+[    1.486373] evm: security.SMACK64MMAP
+[    1.486374] evm: security.apparmor
+[    1.486374] evm: security.ima
+[    1.486374] evm: security.capability
+[    1.486375] evm: HMAC attrs: 0x1
+[    1.495253] usb 1-3: New USB device found, idVendor=05ac, idProduct=1281, bcdDevice= 0.00
+[    1.495254] usb 1-3: New USB device strings: Mfr=2, Product=3, SerialNumber=4
+[    1.495255] usb 1-3: Product: Apple Mobile Device (Recovery Mode)
+[    1.495256] usb 1-3: Manufacturer: Apple Inc.
+[    1.495257] usb 1-3: SerialNumber: CPID:8002 CPRV:10 CPFM:03 SCEP:01 BDID:12 ECID:000C28DA308BAD26 IBFL:3D
+[    1.621908] usb 1-11: new high-speed USB device number 3 using xhci_hcd
+[    1.649897] usb 1-11: New USB device found, idVendor=2109, idProduct=2813, bcdDevice= 2.21
+[    1.649899] usb 1-11: New USB device strings: Mfr=1, Product=2, SerialNumber=0
+[    1.649899] usb 1-11: Product: USB2.0 Hub             
+[    1.649900] usb 1-11: Manufacturer: VIA Labs, Inc.         
+[    1.651365] hub 1-11:1.0: USB hub found
+[    1.652251] hub 1-11:1.0: 4 ports detected
+[    1.668549] PM:   Magic number: 8:680:291
+[    1.668578] tty tty24: hash matches
+[    1.668593] acpi device:8f: hash matches
+[    1.668774] rtc_cmos 00:01: setting system clock to 2020-06-14T18:15:34 UTC (1592158534)
+[    1.669805] Freeing unused decrypted memory: 2040K
+[    1.670186] Freeing unused kernel image (initmem) memory: 2664K
+[    1.670244] Write protecting the kernel read-only data: 22528k
+[    1.670754] Freeing unused kernel image (text/rodata gap) memory: 2044K
+[    1.670981] Freeing unused kernel image (rodata/data gap) memory: 976K
+[    1.677341] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+[    1.677342] x86/mm: Checking user space page tables
+[    1.683626] x86/mm: Checked W+X mappings: passed, no W+X pages found.
+[    1.683627] Run /init as init process
+[    1.746294] [Firmware Bug]: ACPI(GFX0) defines _DOD but not _DOS
+[    1.746314] ACPI: Video Device [GFX0] (multi-head: yes  rom: no  post: no)
+[    1.748321] acpi device:02: registered as cooling_device8
+[    1.748348] input: Video Bus as /devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:01/LNXVIDEO:00/input/input4
+[    1.761803] nvme nvme0: pci function 0000:02:00.0
+[    1.771305] AMD-Vi: AMD IOMMUv2 driver by Joerg Roedel <jroedel@suse.de>
+[    1.771306] AMD-Vi: AMD IOMMUv2 functionality not available on this system
+[    1.802464] [drm] amdgpu kernel modesetting enabled.
+[    1.802511] CRAT table not found
+[    1.802513] Virtual CRAT table created for CPU
+[    1.802513] Parsing CRAT table with 1 nodes
+[    1.802514] Creating topology SYSFS entries
+[    1.802520] Topology: Add CPU node
+[    1.802520] Finished initializing topology
+[    1.802577] checking generic (b0300000 1cb6000) vs hw (b0000000 10000000)
+[    1.802577] fb0: switching to amdgpudrmfb from EFI VGA
+[    1.802617] Console: switching to colour dummy device 80x25
+[    1.802679] amdgpu 0000:01:00.0: vgaarb: deactivate vga console
+[    1.802809] [drm] initializing kernel modesetting (POLARIS11 0x1002:0x67EF 0x106B:0x0160 0xC0).
+[    1.802830] [drm] register mmio base: 0x82600000
+[    1.802830] [drm] register mmio size: 262144
+[    1.802835] [drm] add ip block number 0 <vi_common>
+[    1.802836] [drm] add ip block number 1 <gmc_v8_0>
+[    1.802836] [drm] add ip block number 2 <tonga_ih>
+[    1.802837] [drm] add ip block number 3 <gfx_v8_0>
+[    1.802837] [drm] add ip block number 4 <sdma_v3_0>
+[    1.802838] [drm] add ip block number 5 <powerplay>
+[    1.802838] [drm] add ip block number 6 <dm>
+[    1.802839] [drm] add ip block number 7 <uvd_v6_0>
+[    1.802839] [drm] add ip block number 8 <vce_v3_0>
+[    1.802856] ATOM BIOS: 113-C9801AU-029
+[    1.802865] [drm] UVD is enabled in VM mode
+[    1.802865] [drm] UVD ENC is enabled in VM mode
+[    1.802867] [drm] VCE enabled in VM mode
+[    1.802887] [drm] vm size is 64 GB, 2 levels, block size is 10-bit, fragment size is 9-bit
+[    1.802912] amdgpu 0000:01:00.0: VRAM: 4096M 0x000000F400000000 - 0x000000F4FFFFFFFF (4096M used)
+[    1.802913] amdgpu 0000:01:00.0: GART: 256M 0x000000FF00000000 - 0x000000FF0FFFFFFF
+[    1.802918] [drm] Detected VRAM RAM=4096M, BAR=256M
+[    1.802918] [drm] RAM width 128bits GDDR5
+[    1.802954] [TTM] Zone  kernel: Available graphics memory: 8145658 KiB
+[    1.802954] [TTM] Zone   dma32: Available graphics memory: 2097152 KiB
+[    1.802955] [TTM] Initializing pool allocator
+[    1.802957] [TTM] Initializing DMA pool allocator
+[    1.802981] [drm] amdgpu: 4096M of VRAM memory ready
+[    1.802983] [drm] amdgpu: 4096M of GTT memory ready.
+[    1.802988] [drm] GART: num cpu pages 65536, num gpu pages 65536
+[    1.803538] [drm] PCIE GART of 256M enabled (table at 0x000000F401AEB000).
+[    1.803619] [drm] Chained IB support enabled!
+[    1.804471] amdgpu: [powerplay] hwmgr_sw_init smu backed is polaris10_smu
+[    1.804549] [drm] Found UVD firmware Version: 1.130 Family ID: 16
+[    1.805268] [drm] Found VCE firmware Version: 52.4 Binary ID: 3
+[    1.877845] [drm] DM_PPLIB: values for Engine clock
+[    1.877846] [drm] DM_PPLIB:	 214000
+[    1.877846] [drm] DM_PPLIB:	 320000
+[    1.877846] [drm] DM_PPLIB:	 436000
+[    1.877846] [drm] DM_PPLIB:	 556000
+[    1.877847] [drm] DM_PPLIB:	 671000
+[    1.877847] [drm] DM_PPLIB:	 756000
+[    1.877847] [drm] DM_PPLIB:	 838000
+[    1.877847] [drm] DM_PPLIB:	 907000
+[    1.877848] [drm] DM_PPLIB: Validation clocks:
+[    1.877848] [drm] DM_PPLIB:    engine_max_clock: 90700
+[    1.877849] [drm] DM_PPLIB:    memory_max_clock: 127000
+[    1.877849] [drm] DM_PPLIB:    level           : 8
+[    1.877850] [drm] DM_PPLIB: values for Memory clock
+[    1.877850] [drm] DM_PPLIB:	 300000
+[    1.877850] [drm] DM_PPLIB:	 1270000
+[    1.877851] [drm] DM_PPLIB: Validation clocks:
+[    1.877851] [drm] DM_PPLIB:    engine_max_clock: 90700
+[    1.877851] [drm] DM_PPLIB:    memory_max_clock: 127000
+[    1.877851] [drm] DM_PPLIB:    level           : 8
+[    1.877932] [drm] Display Core initialized with v3.2.56!
+[    1.965769] usb 1-11.2: new high-speed USB device number 4 using xhci_hcd
+[    1.985101] nvme nvme0: 1/0/0 default/read/poll queues
+[    1.986366] usb 1-11.2: New USB device found, idVendor=1a40, idProduct=0101, bcdDevice= 1.11
+[    1.986367] usb 1-11.2: New USB device strings: Mfr=0, Product=1, SerialNumber=0
+[    1.986368] usb 1-11.2: Product: USB 2.0 Hub
+[    1.987096] hub 1-11.2:1.0: USB hub found
+[    1.987188] hub 1-11.2:1.0: 4 ports detected
+[    2.014656]  nvme0n1: p1 p2
+[    2.081741] usb 1-11.3: new high-speed USB device number 5 using xhci_hcd
+[    2.090042] [drm] Supports vblank timestamp caching Rev 2 (21.10.2013).
+[    2.090042] [drm] Driver supports precise vblank timestamp query.
+[    2.117073] usb 1-11.3: New USB device found, idVendor=2109, idProduct=d101, bcdDevice= 3.01
+[    2.117075] usb 1-11.3: New USB device strings: Mfr=1, Product=2, SerialNumber=3
+[    2.117075] usb 1-11.3: Product: USB Keyboard           
+[    2.117076] usb 1-11.3: Manufacturer: VIA Labs, Inc.         
+[    2.117077] usb 1-11.3: SerialNumber: 0000000000000001
+[    2.120527] hid: raw HID events driver (C) Jiri Kosina
+[    2.127615] usbcore: registered new interface driver usbhid
+[    2.127616] usbhid: USB HID core driver
+[    2.129109] hid-generic 0003:2109:D101.0001: hiddev0,hidraw0: USB HID v1.10 Device [VIA Labs, Inc.          USB Keyboard           ] on usb-0000:00:14.0-11.3/input0
+[    2.136258] [drm] UVD and UVD ENC initialized successfully.
+[    2.146209] tsc: Refined TSC clocksource calibration: 2903.971 MHz
+[    2.146213] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x29dbea8485b, max_idle_ns: 440795350411 ns
+[    2.146262] clocksource: Switched to clocksource tsc
+[    2.246207] [drm] VCE initialized successfully.
+[    2.247345] kfd kfd: Allocated 3969056 bytes on gart
+[    2.248014] Virtual CRAT table created for GPU
+[    2.248015] Parsing CRAT table with 1 nodes
+[    2.248017] Creating topology SYSFS entries
+[    2.248048] Topology: Add dGPU node [0x67ef:0x1002]
+[    2.248050] kfd kfd: added device 1002:67ef
+[    2.252029] [drm] fb mappable at 0xB201B000
+[    2.252030] [drm] vram apper at 0xB0000000
+[    2.252030] [drm] size 20738048
+[    2.252031] [drm] fb depth is 24
+[    2.252031] [drm]    pitch is 11520
+[    2.252236] fbcon: amdgpudrmfb (fb0) is primary device
+[    2.307221] Console: switching to colour frame buffer device 240x67
+[    2.324713] amdgpu 0000:01:00.0: fb0: amdgpudrmfb frame buffer device
+[    2.338420] [drm] Initialized amdgpu 3.36.0 20150101 for 0000:01:00.0 on minor 0
+[    2.393775] usb 1-11.2.4: new full-speed USB device number 6 using xhci_hcd
+[    2.616747] usb 1-11.2.4: New USB device found, idVendor=046d, idProduct=c534, bcdDevice=29.01
+[    2.616748] usb 1-11.2.4: New USB device strings: Mfr=1, Product=2, SerialNumber=0
+[    2.616749] usb 1-11.2.4: Product: USB Receiver
+[    2.616750] usb 1-11.2.4: Manufacturer: Logitech
+[    2.617705] raid6: avx2x4   gen() 36665 MB/s
+[    2.623683] input: Logitech USB Receiver as /devices/pci0000:00/0000:00:14.0/usb1/1-11/1-11.2/1-11.2.4/1-11.2.4:1.0/0003:046D:C534.0002/input/input5
+[    2.681975] hid-generic 0003:046D:C534.0002: input,hidraw1: USB HID v1.11 Keyboard [Logitech USB Receiver] on usb-0000:00:14.0-11.2.4/input0
+[    2.684326] input: Logitech USB Receiver Mouse as /devices/pci0000:00/0000:00:14.0/usb1/1-11/1-11.2/1-11.2.4/1-11.2.4:1.1/0003:046D:C534.0003/input/input6
+[    2.684468] input: Logitech USB Receiver Consumer Control as /devices/pci0000:00/0000:00:14.0/usb1/1-11/1-11.2/1-11.2.4/1-11.2.4:1.1/0003:046D:C534.0003/input/input7
+[    2.685705] raid6: avx2x4   xor() 22811 MB/s
+[    2.741836] input: Logitech USB Receiver System Control as /devices/pci0000:00/0000:00:14.0/usb1/1-11/1-11.2/1-11.2.4/1-11.2.4:1.1/0003:046D:C534.0003/input/input8
+[    2.741916] hid-generic 0003:046D:C534.0003: input,hiddev1,hidraw2: USB HID v1.11 Mouse [Logitech USB Receiver] on usb-0000:00:14.0-11.2.4/input1
+[    2.753703] raid6: avx2x2   gen() 31950 MB/s
+[    2.821704] raid6: avx2x2   xor() 20294 MB/s
+[    2.889704] raid6: avx2x1   gen() 26384 MB/s
+[    2.957704] raid6: avx2x1   xor() 19494 MB/s
+[    3.025703] raid6: sse2x4   gen() 15627 MB/s
+[    3.093705] raid6: sse2x4   xor()  9628 MB/s
+[    3.161706] raid6: sse2x2   gen() 13081 MB/s
+[    3.229705] raid6: sse2x2   xor()  8874 MB/s
+[    3.297707] raid6: sse2x1   gen() 12123 MB/s
+[    3.365706] raid6: sse2x1   xor()  6935 MB/s
+[    3.365707] raid6: using algorithm avx2x4 gen() 36665 MB/s
+[    3.365707] raid6: .... xor() 22811 MB/s, rmw enabled
+[    3.365708] raid6: using avx2x2 recovery algorithm
+[    3.367759] xor: automatically using best checksumming function   avx       
+[    3.383331] Btrfs loaded, crc32c=crc32c-intel
+[    3.426341] EXT4-fs (nvme0n1p2): mounted filesystem with ordered data mode. Opts: (null)
+[    3.466311] logitech-djreceiver 0003:046D:C534.0002: hidraw1: USB HID v1.11 Keyboard [Logitech USB Receiver] on usb-0000:00:14.0-11.2.4/input0
+[    3.654504] logitech-djreceiver 0003:046D:C534.0003: hiddev1,hidraw2: USB HID v1.11 Mouse [Logitech USB Receiver] on usb-0000:00:14.0-11.2.4/input1
+[    3.716692] logitech-djreceiver 0003:046D:C534.0003: device of type eQUAD nano Lite (0x0a) connected on slot 1
+[    3.716927] input: Logitech Wireless Keyboard PID:4023 Keyboard as /devices/pci0000:00/0000:00:14.0/usb1/1-11/1-11.2/1-11.2.4/1-11.2.4:1.1/0003:046D:C534.0003/0003:046D:4023.0004/input/input11
+[    3.717023] input: Logitech Wireless Keyboard PID:4023 Consumer Control as /devices/pci0000:00/0000:00:14.0/usb1/1-11/1-11.2/1-11.2.4/1-11.2.4:1.1/0003:046D:C534.0003/0003:046D:4023.0004/input/input12
+[    3.717129] input: Logitech Wireless Keyboard PID:4023 System Control as /devices/pci0000:00/0000:00:14.0/usb1/1-11/1-11.2/1-11.2.4/1-11.2.4:1.1/0003:046D:C534.0003/0003:046D:4023.0004/input/input13
+[    3.717190] hid-generic 0003:046D:4023.0004: input,hidraw3: USB HID v1.11 Keyboard [Logitech Wireless Keyboard PID:4023] on usb-0000:00:14.0-11.2.4/input1:1
+[    3.718625] logitech-djreceiver 0003:046D:C534.0003: device of type eQUAD nano Lite (0x0a) connected on slot 2
+[    3.718804] input: Logitech Wireless Mouse PID:4054 Mouse as /devices/pci0000:00/0000:00:14.0/usb1/1-11/1-11.2/1-11.2.4/1-11.2.4:1.1/0003:046D:C534.0003/0003:046D:4054.0005/input/input18
+[    3.718890] hid-generic 0003:046D:4054.0005: input,hidraw4: USB HID v1.11 Mouse [Logitech Wireless Mouse PID:4054] on usb-0000:00:14.0-11.2.4/input1:2
+[    3.880855] input: Logitech Wireless Keyboard PID:4023 as /devices/pci0000:00/0000:00:14.0/usb1/1-11/1-11.2/1-11.2.4/1-11.2.4:1.1/0003:046D:C534.0003/0003:046D:4023.0004/input/input22
+[    3.880993] logitech-hidpp-device 0003:046D:4023.0004: input,hidraw3: USB HID v1.11 Keyboard [Logitech Wireless Keyboard PID:4023] on usb-0000:00:14.0-11.2.4/input1:1
+[    3.928888] input: Logitech Wireless Mouse as /devices/pci0000:00/0000:00:14.0/usb1/1-11/1-11.2/1-11.2.4/1-11.2.4:1.1/0003:046D:C534.0003/0003:046D:4054.0005/input/input23
+[    3.929269] logitech-hidpp-device 0003:046D:4054.0005: input,hidraw4: USB HID v1.11 Mouse [Logitech Wireless Mouse] on usb-0000:00:14.0-11.2.4/input1:2
+[    4.594249] systemd[1]: systemd 237 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid)
+[    4.614194] systemd[1]: Detected architecture x86-64.
+[    4.631509] systemd[1]: Set hostname to <asimov-MacBookPro>.
+[    4.687371] systemd[1]: Created slice User and Session Slice.
+[    4.687399] systemd[1]: Reached target User and Group Name Lookups.
+[    4.687434] systemd[1]: Started Forward Password Requests to Wall Directory Watch.
+[    4.687441] systemd[1]: Reached target Remote File Systems.
+[    4.687526] systemd[1]: Created slice System Slice.
+[    4.687565] systemd[1]: Listening on fsck to fsckd communication Socket.
+[    4.688710] systemd[1]: Listening on Process Core Dump Socket.
+[    4.700039] EXT4-fs (nvme0n1p2): re-mounted. Opts: errors=remount-ro
+[    4.705379] lp: driver loaded but no devices found
+[    4.710637] ppdev: user-space parallel port driver
+[    4.768115] cryptd: max_cpu_qlen set to 1000
+[    4.774488] AVX2 version of gcm_enc/dec engaged.
+[    4.774490] AES CTR mode by8 optimization enabled
+[    4.792415] systemd-journald[478]: Received request to flush runtime journal from PID 1
+[    4.894738] smbus_hc ACPI0001:00: SBS HC: offset = 0x20, query_bit = 0x10
+[    4.896300] apple_gmux: Found gmux version 4.0.29 [indexed]
+[    4.919184] Bluetooth: Core ver 2.22
+[    4.919200] NET: Registered protocol family 31
+[    4.919201] Bluetooth: HCI device and connection manager initialized
+[    4.919204] Bluetooth: HCI socket layer initialized
+[    4.919205] Bluetooth: L2CAP socket layer initialized
+[    4.919209] Bluetooth: SCO socket layer initialized
+[    4.922003] intel-lpss 0000:00:15.0: enabling device (0000 -> 0002)
+[    4.922313] idma64 idma64.0: Found Intel integrated DMA 64-bit
+[    4.927064] cfg80211: Loading compiled-in X.509 certificates for regulatory database
+[    4.939000] cfg80211: Loaded X.509 cert 'sforshee: 00b28ddf47aef9cea7'
+[    4.941733] intel-lpss 0000:00:19.0: enabling device (0000 -> 0002)
+[    4.961738] intel-lpss 0000:00:1e.0: enabling device (0000 -> 0002)
+[    4.962008] idma64 idma64.2: Found Intel integrated DMA 64-bit
+[    4.966949] RAPL PMU: API unit is 2^-32 Joules, 4 fixed counters, 655360 ms ovfl timer
+[    4.966951] RAPL PMU: hw unit of domain pp0-core 2^-14 Joules
+[    4.966951] RAPL PMU: hw unit of domain package 2^-14 Joules
+[    4.966952] RAPL PMU: hw unit of domain dram 2^-14 Joules
+[    4.966952] RAPL PMU: hw unit of domain pp1-gpu 2^-14 Joules
+[    4.975930] usbcore: registered new interface driver brcmfmac
+[    4.978978] Bluetooth: HCI UART driver ver 2.3
+[    4.978979] Bluetooth: HCI UART protocol H4 registered
+[    4.978980] Bluetooth: HCI UART protocol BCSP registered
+[    4.978989] Bluetooth: HCI UART protocol LL registered
+[    4.978989] Bluetooth: HCI UART protocol ATH3K registered
+[    4.978996] Bluetooth: HCI UART protocol Three-wire (H5) registered
+[    4.979058] Bluetooth: HCI UART protocol Intel registered
+[    4.981822] Bluetooth: HCI UART protocol Broadcom registered
+[    4.981830] Bluetooth: HCI UART protocol QCA registered
+[    4.981836] Bluetooth: HCI UART protocol AG6XX registered
+[    4.982595] intel-lpss 0000:00:1e.1: enabling device (0000 -> 0002)
+[    4.982949] idma64 idma64.3: Found Intel integrated DMA 64-bit
+[    4.983013] snd_hda_intel 0000:01:00.1: enabling device (0000 -> 0002)
+[    4.983070] snd_hda_intel 0000:01:00.1: Force to non-snoop mode
+[    4.986529] Bluetooth: HCI UART protocol Marvell registered
+[    4.992447] snd_hda_intel 0000:01:00.1: bound 0000:01:00.0 (ops amdgpu_dm_audio_component_bind_ops [amdgpu])
+[    4.997676] input: HDA ATI HDMI HDMI/DP,pcm=3 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card1/input24
+[    4.997766] input: HDA ATI HDMI HDMI/DP,pcm=7 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card1/input25
+[    4.997811] input: HDA ATI HDMI HDMI/DP,pcm=8 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card1/input26
+[    4.997844] input: HDA ATI HDMI HDMI/DP,pcm=9 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card1/input27
+[    4.997879] input: HDA ATI HDMI HDMI/DP,pcm=10 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card1/input28
+[    4.997911] input: HDA ATI HDMI HDMI/DP,pcm=11 as /devices/pci0000:00/0000:00:01.0/0000:01:00.1/sound/card1/input29
+[    5.001796] intel-lpss 0000:00:1e.2: enabling device (0000 -> 0002)
+[    5.002185] idma64 idma64.4: Found Intel integrated DMA 64-bit
+[    5.020294] snd_hda_codec_cirrus: loading out-of-tree module taints kernel.
+[    5.020339] snd_hda_codec_cirrus: module verification failed: signature and/or required key missing - tainting kernel
+[    5.021143] snd_hda_codec_cirrus hdaudioC0D0: autoconfig for CS8409: line_outs=2 (0x24/0x25/0x0/0x0/0x0) type:speaker
+[    5.021145] snd_hda_codec_cirrus hdaudioC0D0:    speaker_outs=0 (0x0/0x0/0x0/0x0/0x0)
+[    5.021147] snd_hda_codec_cirrus hdaudioC0D0:    hp_outs=1 (0x2c/0x0/0x0/0x0/0x0)
+[    5.021149] snd_hda_codec_cirrus hdaudioC0D0:    mono: mono_out=0x0
+[    5.021150] snd_hda_codec_cirrus hdaudioC0D0:    inputs:
+[    5.021152] snd_hda_codec_cirrus hdaudioC0D0:      Internal Mic=0x44
+[    5.021154] snd_hda_codec_cirrus hdaudioC0D0:      Mic=0x3c
+[    5.021785] intel-lpss 0000:00:1e.3: enabling device (0000 -> 0002)
+[    5.022152] idma64 idma64.5: Found Intel integrated DMA 64-bit
+[    5.044304] audit: type=1400 audit(1592158537.869:2): apparmor="STATUS" operation="profile_load" profile="unconfined" name="libreoffice-xpdfimport" pid=741 comm="apparmor_parser"
+[    5.050135] audit: type=1400 audit(1592158537.877:3): apparmor="STATUS" operation="profile_load" profile="unconfined" name="/sbin/dhclient" pid=735 comm="apparmor_parser"
+[    5.050138] audit: type=1400 audit(1592158537.877:4): apparmor="STATUS" operation="profile_load" profile="unconfined" name="/usr/lib/NetworkManager/nm-dhcp-client.action" pid=735 comm="apparmor_parser"
+[    5.050140] audit: type=1400 audit(1592158537.877:5): apparmor="STATUS" operation="profile_load" profile="unconfined" name="/usr/lib/NetworkManager/nm-dhcp-helper" pid=735 comm="apparmor_parser"
+[    5.050142] audit: type=1400 audit(1592158537.877:6): apparmor="STATUS" operation="profile_load" profile="unconfined" name="/usr/lib/connman/scripts/dhclient-script" pid=735 comm="apparmor_parser"
+[    5.053108] audit: type=1400 audit(1592158537.877:7): apparmor="STATUS" operation="profile_load" profile="unconfined" name="/usr/lib/cups/backend/cups-pdf" pid=744 comm="apparmor_parser"
+[    5.053112] audit: type=1400 audit(1592158537.877:8): apparmor="STATUS" operation="profile_load" profile="unconfined" name="/usr/sbin/cupsd" pid=744 comm="apparmor_parser"
+[    5.053115] audit: type=1400 audit(1592158537.877:9): apparmor="STATUS" operation="profile_load" profile="unconfined" name="/usr/sbin/cupsd//third_party" pid=744 comm="apparmor_parser"
+[    5.055824] audit: type=1400 audit(1592158537.881:10): apparmor="STATUS" operation="profile_load" profile="unconfined" name="/usr/sbin/ippusbxd" pid=745 comm="apparmor_parser"
+[    5.082138] brcmfmac: brcmf_fw_alloc_request: using brcm/brcmfmac43602-pcie for chip BCM43602/2
+[    5.083451] brcmfmac 0000:03:00.0: Direct firmware load for brcm/brcmfmac43602-pcie.Apple Inc.-MacBookPro13,3.txt failed with error -2
+[    5.114726] applesmc: key=858 fan=2 temp=46 index=45 acc=0 lux=0 kbd=0
+[    5.114824] applesmc applesmc.768: hwmon_device_register() is deprecated. Please convert the driver to use hwmon_device_register_with_info().
+[    5.155314] dw-apb-uart.1: ttyS4 at MMIO 0x8272a000 (irq = 21, base_baud = 115200) is a 16550A
+[    5.155777] serial serial0: tty port ttyS4 registered
+[    5.184783] dw-apb-uart.2: ttyS5 at MMIO 0x8272b000 (irq = 20, base_baud = 3000000) is a 16550A
+[    5.185481] serial serial1: tty port ttyS5 registered
+[    5.191462] intel_rapl_common: Found RAPL domain package
+[    5.191464] intel_rapl_common: Found RAPL domain core
+[    5.191465] intel_rapl_common: Found RAPL domain uncore
+[    5.191466] intel_rapl_common: Found RAPL domain dram
+[    5.206531] dw-apb-uart.3: ttyS6 at MMIO 0x8272c000 (irq = 21, base_baud = 115200) is a 16550A
+[    5.207830] serial serial2: tty port ttyS6 registered
+[    5.210121] input: Apple SPI Keyboard as /devices/pci0000:00/0000:00:1e.3/pxa2xx-spi.5/spi_master/spi2/spi-APP000D:00/input/input30
+[    5.216774] input: Apple SPI Touchpad as /devices/pci0000:00/0000:00:1e.3/pxa2xx-spi.5/spi_master/spi2/spi-APP000D:00/input/input31
+[    5.221939] hci_uart_bcm serial1-0: Unexpected ACPI gpio_int_idx: -1
+[    5.221941] hci_uart_bcm serial1-0: Unexpected number of ACPI GPIOs: 0
+[    5.221950] hci_uart_bcm serial1-0: No reset resource, using default baud rate
+[    5.224283] applespi spi-APP000D:00: Received corrupted packet (crc mismatch)
+[    5.239141] ACPI: Smart Battery System [SBS0]: Battery Slot [BAT0] (battery present)
+[    5.295755] brcmfmac: brcmf_fw_alloc_request: using brcm/brcmfmac43602-pcie for chip BCM43602/2
+[    5.295778] brcmfmac: brcmf_c_process_clm_blob: no clm_blob available (err=-2), device may have limited channels available
+[    5.296411] brcmfmac: brcmf_c_preinit_dcmds: Firmware: BCM43602/2 wl0: Nov 10 2015 06:38:10 version 7.35.177.61 (r598657) FWID 01-ea662a8c
+[    5.350469] brcmfmac 0000:03:00.0 wlp3s0: renamed from wlan0
+[    5.362119] Adding 2096636k swap on /dev/mapper/cryptswap1.  Priority:-2 extents:1 across:2096636k SSFS
+[    5.750910] Bluetooth: hci0: BCM: failed to write update baudrate (-16)
+[    5.750911] Bluetooth: hci0: Failed to set baudrate
+[    5.767822] Bluetooth: BNEP (Ethernet Emulation) ver 1.3
+[    5.767823] Bluetooth: BNEP filters: protocol multicast
+[    5.767825] Bluetooth: BNEP socket layer initialized
+[    5.863408] Bluetooth: hci0: BCM: chip id 126
+[    5.864257] Bluetooth: hci0: BCM: features 0x2f
+[    5.866376] Bluetooth: hci0: BCM20703A2 Generic UART UHE Apple 40MHz wlcsp_x100
+[    5.866382] Bluetooth: hci0: BCM (001.002.091) build 0205
+[    5.866423] bluetooth hci0: Direct firmware load for brcm/BCM.hcd failed with error -2
+[    5.866427] Bluetooth: hci0: BCM: Patch brcm/BCM.hcd not found
+[    9.590904] logitech-hidpp-device 0003:046D:4023.0004: HID++ 2.0 device connected.
+[   11.617300] Could not find key with description: [91354bd60e2a0138]
+[   11.617304] process_request_key_err: No key
+[   11.617305] Could not find valid key in user session keyring for sig specified in mount option: [91354bd60e2a0138]
+[   11.617306] One or more global auth toks could not properly register; rc = [-2]
+[   11.617307] Error parsing options; rc = [-2]
+[   13.584522] Bluetooth: RFCOMM TTY layer initialized
+[   13.584532] Bluetooth: RFCOMM socket layer initialized
+[   13.584538] Bluetooth: RFCOMM ver 1.11
+[   16.429028] IPv6: ADDRCONF(NETDEV_CHANGE): wlp3s0: link becomes ready
+[   16.491160] ieee80211 phy0: brcmf_inetaddr_changed: fail to get arp ip table err:-52
+[   17.758913] logitech-hidpp-device 0003:046D:4054.0005: HID++ 4.5 device connected.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ There is also a chat available via gitter for discussions:
 
 | Device  | Status |
 | ------- | ------ |
-| [Audio input & output](#audio-input--output) | ![all models not working](https://img.shields.io/badge/all_models-not_working-red.svg) |
+| [Audio input & output](#audio-input--output) | ![MacBookPro13,1 not working](https://img.shields.io/badge/MacBookPro13%2C1-not_working-red.svg) ![MacBookPro13,2 not working](https://img.shields.io/badge/MacBookPro13%2C2-not_working-red.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-_working-green.svg) ![MacBookPro14,1 not working](https://img.shields.io/badge/MacBookPro14%2C1-not_working-red.svg) ![MacBookPro14,2 not working](https://img.shields.io/badge/MacBookPro14%2C2-not_working-red.svg) ![MacBookPro14,3 not working](https://img.shields.io/badge/MacBookPro14%2C3-not_working-red.svg) ![MacBookPro16,1 not working](https://img.shields.io/badge/MacBookPro16%2C1-not_working-red.svg) |
 | [Battery](#battery) | ![all models working](https://img.shields.io/badge/all_models-working-green.svg) |
 | [Bluetooth](#bluetooth) | ![all models working](https://img.shields.io/badge/all_models-working-green.svg) |
 | [FaceTime HD camera](#facetime-hd-camera) | ![all models working](https://img.shields.io/badge/all_models-working-green.svg) |
@@ -54,12 +54,13 @@ There is also a chat available via gitter for discussions:
 
 ## Audio input & output
 
-![MacBookPro13,1 not working](https://img.shields.io/badge/MacBookPro13%2C1-not_working-red.svg) ![MacBookPro13,2 not working](https://img.shields.io/badge/MacBookPro13%2C2-not_working-red.svg) ![MacBookPro13,3 not working](https://img.shields.io/badge/MacBookPro13%2C3-not_working-red.svg) ![MacBookPro14,1 not working](https://img.shields.io/badge/MacBookPro14%2C1-not_working-red.svg) ![MacBookPro14,2 not working](https://img.shields.io/badge/MacBookPro14%2C2-not_working-red.svg) ![MacBookPro14,3 not working](https://img.shields.io/badge/MacBookPro14%2C3-not_working-red.svg)  ![MacBookPro16,1 not working](https://img.shields.io/badge/MacBookPro16%2C1-not_working-red.svg)
+![MacBookPro13,1 not working](https://img.shields.io/badge/MacBookPro13%2C1-not_working-red.svg) ![MacBookPro13,2 not working](https://img.shields.io/badge/MacBookPro13%2C2-not_working-red.svg) ![MacBookPro13,3 working](https://img.shields.io/badge/MacBookPro13%2C3-working-green.svg) ![MacBookPro14,1 not working](https://img.shields.io/badge/MacBookPro14%2C1-not_working-red.svg) ![MacBookPro14,2 not working](https://img.shields.io/badge/MacBookPro14%2C2-not_working-red.svg) ![MacBookPro14,3 not working](https://img.shields.io/badge/MacBookPro14%2C3-not_working-red.svg)  ![MacBookPro16,1 not working](https://img.shields.io/badge/MacBookPro16%2C1-not_working-red.svg)
 
-Not working, neither the internal speakers/microphone nor the headphone jack.
+Internal audio input & output has been verified and is working for MacBookPro13,3 by installing the Cirrus 8409
+firmware patch from https://github.com/davidjo/snd_hda_macbookpro for kernel version 5.5+.
 
-What's working is audio via HDMI or any USB-connected audio device, so that can
-act as a workaround until internal audio is working.
+For the rest of the MacBook Pro models the audio via HDMI or any USB-connected audio device is working,
+so at least they can act as a workaround until internal audio is working.
 
 See also:
 


### PR DESCRIPTION
Internal audio and microphone is working when applying the Cirrus 8409
patch from https://github.com/davidjo/snd_hda_macbookpro for kernel
version 5.5+.