### PR TITLE
Forked repo for touchbar driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ Starting with Linux 5.9 a forked version of the driver is necessary, which is
 available at https://github.com/PatrickVerner/macbook12-spi-driver
 
 Starting with Linux 6.0 PatrickVerner's driver fails to build. It builds when 
-one disables the saving of backlight strength to efi as in this fork
-https://github.com/marc-git/macbook12-spi-driver
+one disables the saving of backlight strength to efi as in this fork (tested on 
+14,3) https://github.com/marc-git/macbook12-spi-driver
 
 Missing is as of now just the advanced functionality with custom graphics Apple
 offers in macOS.

--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ git repository: https://github.com/roadrunner2/macbook12-spi-driver
 Starting with Linux 5.9 a forked version of the driver is necessary, which is
 available at https://github.com/PatrickVerner/macbook12-spi-driver
 
+Starting with Linux 6.0 PatrickVerner's driver fails to build. It builds when 
+one disables the saving of backlight strength to efi as in this fork
+https://github.com/marc-git/macbook12-spi-driver
+
 Missing is as of now just the advanced functionality with custom graphics Apple
 offers in macOS.
 


### PR DESCRIPTION
I only disabled the saving and recalling of the backlight state to efi so that it would compile. It works on my 14,3. 

This change gives people a copy-paste workaround. 